### PR TITLE
ignore deadtuples if not superuser and ext not installed

### DIFF
--- a/gauges/deadtuples_test.go
+++ b/gauges/deadtuples_test.go
@@ -21,3 +21,20 @@ func TestDeadTuples(t *testing.T) {
 	}
 	assertNoErrs(t, gauges)
 }
+
+func TestDeadTuplesWithoutPgstatTuple(t *testing.T) {
+	var assert = assert.New(t)
+	db, gauges, close := prepare(t)
+	defer close()
+	_, err := db.Exec("CREATE TABLE IF NOT EXISTS testtable(id bigint)")
+	assert.NoError(err)
+	_, err = db.Exec("DROP EXTENSION IF EXISTS pgstattuple")
+	assert.NoError(err)
+
+	var metrics = evaluate(t, gauges.DeadTuples())
+	assert.Len(metrics, 1)
+	for _, m := range metrics {
+		assert.Equal(0.0, m.Value)
+	}
+	assertErrs(t, gauges, 1)
+}

--- a/gauges/gauge.go
+++ b/gauges/gauge.go
@@ -50,15 +50,15 @@ func isSuperuser(db *sqlx.DB) (super bool) {
 }
 
 func (g *Gauges) hasExtension(ext string) bool {
-	var count []int64
-	if err := g.query(
-		"select count(*) from pg_available_extensions where name = $1",
+	var count int64
+	if err := g.db.Get(
 		&count,
-		paramsFix([]string{ext}),
+		"select count(*) from pg_available_extensions where name = $1",
+		ext,
 	); err != nil {
 		log.WithError(err).Errorf("failed to determine if %s is installed", ext)
 	}
-	return count[0] > 0
+	return count > 0
 }
 
 func paramsFix(params []string) []interface{} {

--- a/gauges/gauge_test.go
+++ b/gauges/gauge_test.go
@@ -48,6 +48,13 @@ func assertNoErrs(t *testing.T, gauges *Gauges) {
 	assert.Equal(0.0, errs[0].Value)
 }
 
+func assertErrs(t *testing.T, gauges *Gauges, errors int) {
+	var assert = assert.New(t)
+	var errs = evaluate(t, gauges.Errs)
+	assert.Len(errs, 1)
+	assert.Equal(float64(errors), errs[0].Value)
+}
+
 func assertGreaterThan(t *testing.T, expected float64, m Metric) {
 	var assert = assert.New(t)
 	assert.True(


### PR DESCRIPTION
avoid getting into an infinite stream of errors when the user is not a super user or the extension is not installed.