### PR TITLE
dead tuples: increased timeouts and running fewer times

### DIFF
--- a/gauges/deadtuples.go
+++ b/gauges/deadtuples.go
@@ -12,12 +12,11 @@ type Relation struct {
 }
 
 func (g *Gauges) DeadTuples() *prometheus.GaugeVec {
-	var opts = prometheus.GaugeOpts{
+	var gauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        "postgresql_dead_tuples_pct",
 		Help:        "dead tuples percentage on the top 20 biggest tables",
 		ConstLabels: g.labels,
-	}
-	var gauge = prometheus.NewGaugeVec(opts, []string{"table"})
+	}, []string{"table"})
 
 	if !g.isSuperuser {
 		g.Errs.Inc()
@@ -50,7 +49,7 @@ func (g *Gauges) DeadTuples() *prometheus.GaugeVec {
 					&pct,
 					[]interface{}{table.Name},
 					1*time.Minute,
-				); err != nil {
+				); err == nil {
 					gauge.With(prometheus.Labels{"table": table.Name}).Set(pct[0])
 				}
 			}

--- a/gauges/gauge.go
+++ b/gauges/gauge.go
@@ -126,10 +126,23 @@ func (g *Gauges) observe(gauge prometheus.Gauge, query string, params []interfac
 
 var emptyParams = []interface{}{}
 
-func (g *Gauges) query(query string, result interface{}, params []interface{}) error {
+func (g *Gauges) query(
+	query string,
+	result interface{},
+	params []interface{},
+) error {
+	return g.queryWithTimeout(query, result, params, g.timeout)
+}
+
+func (g *Gauges) queryWithTimeout(
+	query string,
+	result interface{},
+	params []interface{},
+	timeout time.Duration,
+) error {
 	ctx, cancel := context.WithDeadline(
 		context.Background(),
-		time.Now().Add(g.timeout),
+		time.Now().Add(timeout),
 	)
 	defer func() {
 		<-ctx.Done()

--- a/gauges/gauge.go
+++ b/gauges/gauge.go
@@ -86,7 +86,6 @@ func (g *Gauges) hasExtension(ext string) bool {
 		log.WithError(err).Errorf("failed to determine if %s is installed", ext)
 	}
 	cancel()
-	log.Infof("count %d", count)
 	return count > 0
 }
 


### PR DESCRIPTION
the call to really big tables can take a long time, so, this increases the timeout and the time between each run.