### PR TITLE
New Metric: Not granted locks

### DIFF
--- a/gauges/locks_test.go
+++ b/gauges/locks_test.go
@@ -15,3 +15,13 @@ func TestLocks(t *testing.T) {
 	assertGreaterThan(t, -1, metrics[0])
 	assertNoErrs(t, gauges)
 }
+
+func TestNotGrantedLocks(t *testing.T) {
+	var assert = assert.New(t)
+	_, gauges, close := prepare(t)
+	defer close()
+	var metrics = evaluate(t, gauges.NotGrantedLocks())
+	assert.Len(metrics, 1)
+	assertGreaterThan(t, -1, metrics[0])
+	assertNoErrs(t, gauges)
+}


### PR DESCRIPTION
Add a new metric: `postgresql_not_granted_locks`.

This metric represents the number of not granted locks. It indicates that are transactions currently waiting to acquire a lock, which implies that some other transaction is holding a conflicting lock mode on the same lockable object. 