### PR TITLE
Improve docker tags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,10 @@ archive:
   - config.yml
 dockers:
 - image: caninjas/postgresql_exporter
-  latest: true
+  tag_templates:
+    - '{{ .Tag }}'
+    - 'v{{ .Major }}'
+    - 'v{{ .Major }}.{{ .Minor }}'
+    - latest
   extra_files:
   - config.yml


### PR DESCRIPTION
Now we push multiple tags to dockerhub: `latest`, `v0`, `v0.2`, `v0.2.0`