### PR TITLE
Improving table metrics

### DIFF
--- a/gauges/tables.go
+++ b/gauges/tables.go
@@ -218,7 +218,10 @@ func (g *Gauges) TableUsage() *prometheus.GaugeVec {
 }
 
 var tableSecScansQuery = `
-	select relname, coalesce(seq_scan, 0), icoalesce(idx_scan, 0) from pg_stat_user_tables
+	select relname, 
+		coalesce(seq_scan, 0) as seq_scan, 
+		coalesce(idx_scan, 0) as idx_scan
+	from pg_stat_user_tables
 `
 
 type tableScans struct {

--- a/gauges/tables.go
+++ b/gauges/tables.go
@@ -237,7 +237,7 @@ type tableScans struct {
 func (g *Gauges) TableScans() *prometheus.GaugeVec {
 	var gauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name:        "postgresql_scans",
+			Name:        "postgresql_table_scans",
 			Help:        "table scans statistics",
 			ConstLabels: g.labels,
 		},

--- a/gauges/tables.go
+++ b/gauges/tables.go
@@ -228,7 +228,7 @@ var tableSecScansQuery = `
 	select relname, seq_scan from pg_stat_user_tables
 `
 
-type tableSecScans struct {
+type tableScans struct {
 	Name    string  `db:"relname"`
 	SecScan float64 `db:"seq_scan"`
 	IdxScan float64 `db:"seq_scan"`
@@ -245,7 +245,7 @@ func (g *Gauges) TableScans() *prometheus.GaugeVec {
 	)
 	go func() {
 		for {
-			var tables []tableSecScans
+			var tables []tableScans
 			if err := g.query(tableSecScansQuery, &tables, emptyParams); err == nil {
 				for _, table := range tables {
 					gauge.With(prometheus.Labels{

--- a/gauges/tables.go
+++ b/gauges/tables.go
@@ -156,20 +156,13 @@ func (g *Gauges) TableBloat() *prometheus.GaugeVec {
 }
 
 var tableUsageQuery = `
-	WITH top_big_tables as (
-	SELECT relname, pg_total_relation_size(relid)
-	FROM pg_catalog.pg_statio_user_tables
-	ORDER BY pg_total_relation_size(relid) desc
-	LIMIT 20
-	)
 	SELECT  s.relname,
 			coalesce(s.seq_tup_read, 0) as seq_tup_read,
 			coalesce(s.idx_tup_fetch, 0) as idx_tup_fetch,
 			coalesce(s.n_tup_ins, 0) as n_tup_ins,
 			coalesce(s.n_tup_upd, 0) as n_tup_upd,
 			coalesce(s.n_tup_del, 0) as n_tup_del
-	FROM top_big_tables tbt
-	JOIN pg_stat_all_tables s on s.relname = tbt.relname
+	FROM pg_stat_user_tables s
 	ORDER BY 2 desc
 `
 
@@ -225,13 +218,13 @@ func (g *Gauges) TableUsage() *prometheus.GaugeVec {
 }
 
 var tableSecScansQuery = `
-	select relname, seq_scan from pg_stat_user_tables
+	select relname, coalesce(seq_scan, 0), icoalesce(idx_scan, 0) from pg_stat_user_tables
 `
 
 type tableScans struct {
 	Name    string  `db:"relname"`
 	SecScan float64 `db:"seq_scan"`
-	IdxScan float64 `db:"seq_scan"`
+	IdxScan float64 `db:"idx_scan"`
 }
 
 func (g *Gauges) TableScans() *prometheus.GaugeVec {

--- a/gauges/tables_test.go
+++ b/gauges/tables_test.go
@@ -24,3 +24,12 @@ func TestTableUsage(t *testing.T) {
 	assert.True(len(metrics) > 0)
 	assertNoErrs(t, gauges)
 }
+
+func TestTableScans(t *testing.T) {
+	var assert = assert.New(t)
+	_, gauges, close := prepare(t)
+	defer close()
+	var metrics = evaluate(t, gauges.TableScans())
+	assert.True(len(metrics) > 0)
+	assertNoErrs(t, gauges)
+}

--- a/main.go
+++ b/main.go
@@ -103,4 +103,5 @@ func watch(db *sql.DB, reg prometheus.Registerer, name string) {
 	reg.MustRegister(gauges.TransactionsSum())
 	reg.MustRegister(gauges.UnusedIndexes())
 	reg.MustRegister(gauges.Up())
+	reg.MustRegister(gauges.TableScans())
 }


### PR DESCRIPTION
If accepted this pull request will:
- Export postgresql_table_scans metric that collects the sec_scan and idx_scan from all database tables.
- Remove the limit to table usage metrics;

@ContaAzul/sre 