### PR TITLE
Adding metrics for database tuples returned and fetched

### DIFF
--- a/gauges/read_throughput.go
+++ b/gauges/read_throughput.go
@@ -1,0 +1,47 @@
+package gauges
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var databaseReadingUsageQuery = `
+	SELECT tup_returned
+		 , tup_fetched 
+	  FROM pg_stat_database 
+	 WHERE datname = current_database()
+`
+
+type readingUsage struct {
+	TuplesRedurned float64 `db:"tup_returned"`
+	TuplesFetched  float64 `db:"tup_fetched"`
+}
+
+func (g *Gauges) DatabaseReadingUsage() *prometheus.GaugeVec {
+	var gauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:        "postgresql_database_reading_usage",
+			Help:        "Database reading usage statistics",
+			ConstLabels: g.labels,
+		},
+		[]string{"stat"},
+	)
+	go func() {
+		for {
+			var readingUsage []readingUsage
+			if err := g.query(databaseReadingUsageQuery, &readingUsage, emptyParams); err == nil {
+				for _, database := range readingUsage {
+					gauge.With(prometheus.Labels{
+						"stat": "tup_fetched",
+					}).Set(database.TuplesFetched)
+					gauge.With(prometheus.Labels{
+						"stat": "tup_returned",
+					}).Set(database.TuplesRedurned)
+				}
+			}
+			time.Sleep(g.interval)
+		}
+	}()
+	return gauge
+}

--- a/gauges/read_throughput_test.go
+++ b/gauges/read_throughput_test.go
@@ -1,0 +1,16 @@
+package gauges
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatabaseReadingUsage(t *testing.T) {
+	var assert = assert.New(t)
+	_, gauges, close := prepare(t)
+	defer close()
+	var metrics = evaluate(t, gauges.DatabaseReadingUsage())
+	assert.True(len(metrics) > 0)
+	assertNoErrs(t, gauges)
+}

--- a/main.go
+++ b/main.go
@@ -103,4 +103,7 @@ func watch(db *sql.DB, reg prometheus.Registerer, name string) {
 	reg.MustRegister(gauges.TransactionsSum())
 	reg.MustRegister(gauges.UnusedIndexes())
 	reg.MustRegister(gauges.Up())
+	reg.MustRegister(gauges.TableScans())
+	reg.MustRegister(gauges.DatabaseReadingUsage())
+
 }


### PR DESCRIPTION
Following this post https://www.datadoghq.com/blog/aws-rds-postgresql-monitoring/

`tup_returned` is the number of rows read/scanned.
`tup_fetched` is the metric that counts how many rows contained data that was actually needed to execute the query.

So this pull request adds the tup_returned and tup_fetched to collected metrics.

@ContaAzul/sre 