### PR TITLE
Heap only updates

### DIFF
--- a/gauges/read_throughput.go
+++ b/gauges/read_throughput.go
@@ -7,8 +7,8 @@ import (
 )
 
 var databaseReadingUsageQuery = `
-	SELECT coalesce(tup_returned, 0)
-		 , coalesce(tup_fetched, 0) 
+	SELECT coalesce(tup_returned, 0) as tup_returned
+		 , coalesce(tup_fetched, 0) as tup_returned
 	  FROM pg_stat_database 
 	 WHERE datname = current_database()
 `

--- a/gauges/read_throughput.go
+++ b/gauges/read_throughput.go
@@ -7,8 +7,8 @@ import (
 )
 
 var databaseReadingUsageQuery = `
-	SELECT tup_returned
-		 , tup_fetched 
+	SELECT coalesce(tup_returned, 0)
+		 , coalesce(tup_fetched, 0) 
 	  FROM pg_stat_database 
 	 WHERE datname = current_database()
 `

--- a/gauges/tables.go
+++ b/gauges/tables.go
@@ -263,7 +263,7 @@ func (g *Gauges) TableScans() *prometheus.GaugeVec {
 
 var hotUpdatesQuery = `
 SELECT relname
-	 , n_tup_hot_upd 
+	 , coalesce(n_tup_hot_upd, 0) 
   FROM pg_stat_user_tables
 `
 
@@ -276,7 +276,7 @@ func (g *Gauges) HOTUpdates() *prometheus.GaugeVec {
 	var gauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name:        "postgresql_hot_updates",
-			Help:        "Heap-Only tuple updates metric",
+			Help:        "Number of rows Heap-Only tuple updated",
 			ConstLabels: g.labels,
 		},
 		[]string{"table"},

--- a/gauges/tables.go
+++ b/gauges/tables.go
@@ -263,7 +263,7 @@ func (g *Gauges) TableScans() *prometheus.GaugeVec {
 
 var hotUpdatesQuery = `
 SELECT relname
-	 , coalesce(n_tup_hot_upd, 0) 
+	 , coalesce(n_tup_hot_upd, 0) as n_tup_hot_upd
   FROM pg_stat_user_tables
 `
 

--- a/gauges/tables.go
+++ b/gauges/tables.go
@@ -260,3 +260,40 @@ func (g *Gauges) TableScans() *prometheus.GaugeVec {
 
 	return gauge
 }
+
+var hotUpdatesQuery = `
+SELECT relname
+	 , n_tup_hot_upd 
+  FROM pg_stat_user_tables
+`
+
+type tableHotUpdates struct {
+	Name       string  `db:"relname"`
+	HotUpdates float64 `db:"n_tup_hot_upd"`
+}
+
+func (g *Gauges) HOTUpdates() *prometheus.GaugeVec {
+	var gauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:        "postgresql_hot_updates",
+			Help:        "Heap-Only tuple updates metric",
+			ConstLabels: g.labels,
+		},
+		[]string{"table"},
+	)
+	go func() {
+		for {
+			var tables []tableHotUpdates
+			if err := g.query(hotUpdatesQuery, &tables, emptyParams); err == nil {
+				for _, table := range tables {
+					gauge.With(prometheus.Labels{
+						"table": table.Name,
+					}).Set(table.HotUpdates)
+				}
+			}
+			time.Sleep(g.interval)
+		}
+	}()
+
+	return gauge
+}

--- a/gauges/tables_test.go
+++ b/gauges/tables_test.go
@@ -33,3 +33,12 @@ func TestTableScans(t *testing.T) {
 	assert.True(len(metrics) > 0)
 	assertNoErrs(t, gauges)
 }
+
+func TestHOTUpdates(t *testing.T) {
+	var assert = assert.New(t)
+	_, gauges, close := prepare(t)
+	defer close()
+	var metrics = evaluate(t, gauges.HOTUpdates())
+	assert.True(len(metrics) > 0)
+	assertNoErrs(t, gauges)
+}

--- a/main.go
+++ b/main.go
@@ -105,5 +105,6 @@ func watch(db *sql.DB, reg prometheus.Registerer, name string) {
 	reg.MustRegister(gauges.Up())
 	reg.MustRegister(gauges.TableScans())
 	reg.MustRegister(gauges.DatabaseReadingUsage())
+	reg.MustRegister(gauges.HOTUpdates())
 
 }


### PR DESCRIPTION
Following this posts https://www.datadoghq.com/blog/aws-rds-postgresql-monitoring/ this pull requests adds the metric to collect `n_tup_hot_upd`. It'll be used with `n_tup_upd` to mensure the update efficiency.

@ContaAzul/sre 