### PR TITLE
Database Writing usage.

### DIFF
--- a/gauges/write_throughput.go
+++ b/gauges/write_throughput.go
@@ -7,9 +7,9 @@ import (
 )
 
 var databaseWritingUsageQuery = `
-	SELECT tup_inserted
-		 , tup_updated
-		 , tup_deleted 
+	SELECT coalesce(tup_inserted, 0) as tup_inserted
+		 , coalesce(tup_updated, 0) as tup_updated
+		 , coalesce(tup_deleted, 0) as tup_deleted
 	  FROM pg_stat_database 
 	 WHERE datname = current_database()
 `

--- a/gauges/write_throughput.go
+++ b/gauges/write_throughput.go
@@ -1,0 +1,52 @@
+package gauges
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var databaseWritingUsageQuery = `
+	SELECT tup_inserted
+		 , tup_updated
+		 , tup_deleted 
+	  FROM pg_stat_database 
+	 WHERE datname = current_database()
+`
+
+type writingUsage struct {
+	TuplesInserted float64 `db:"tup_inserted"`
+	TuplesUpdated  float64 `db:"tup_updated"`
+	TuplesDeleted  float64 `db:"tup_deleted"`
+}
+
+func (g *Gauges) DatabaseWritingUsage() *prometheus.GaugeVec {
+	var gauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:        "postgresql_database_writing_usage",
+			Help:        "Database writing usage statistics",
+			ConstLabels: g.labels,
+		},
+		[]string{"stat"},
+	)
+	go func() {
+		for {
+			var writingUsage []writingUsage
+			if err := g.query(databaseWritingUsageQuery, &writingUsage, emptyParams); err == nil {
+				for _, database := range writingUsage {
+					gauge.With(prometheus.Labels{
+						"stat": "tup_inserted",
+					}).Set(database.TuplesInserted)
+					gauge.With(prometheus.Labels{
+						"stat": "tup_updated",
+					}).Set(database.TuplesUpdated)
+					gauge.With(prometheus.Labels{
+						"stat": "tup_deleted",
+					}).Set(database.TuplesDeleted)
+				}
+			}
+			time.Sleep(g.interval)
+		}
+	}()
+	return gauge
+}

--- a/gauges/write_throughput.go
+++ b/gauges/write_throughput.go
@@ -24,7 +24,7 @@ func (g *Gauges) DatabaseWritingUsage() *prometheus.GaugeVec {
 	var gauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name:        "postgresql_database_writing_usage",
-			Help:        "Database writing usage statistics",
+			Help:        "Number of inserted, updated and deleted rows per database",
 			ConstLabels: g.labels,
 		},
 		[]string{"stat"},

--- a/gauges/write_throughput_test.go
+++ b/gauges/write_throughput_test.go
@@ -1,0 +1,16 @@
+package gauges
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatabaseWritingUsage(t *testing.T) {
+	var assert = assert.New(t)
+	_, gauges, close := prepare(t)
+	defer close()
+	var metrics = evaluate(t, gauges.DatabaseWritingUsage())
+	assert.True(len(metrics) > 0)
+	assertNoErrs(t, gauges)
+}

--- a/main.go
+++ b/main.go
@@ -105,6 +105,7 @@ func watch(db *sql.DB, reg prometheus.Registerer, name string) {
 	reg.MustRegister(gauges.Up())
 	reg.MustRegister(gauges.TableScans())
 	reg.MustRegister(gauges.DatabaseReadingUsage())
+	reg.MustRegister(gauges.DatabaseWritingUsage())
 	reg.MustRegister(gauges.HOTUpdates())
 
 }


### PR DESCRIPTION
Collecting `tup_inserted`, `tup_updated` and `tup_deleted` at database level.

This metric will be used to know why the database is used for. If update and delete rate is high, we should take a look to dead rows.

@ContaAzul/sre 