### PR TITLE
Added dead rows metrics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,6 @@ dist: trusty
 sudo: required
 language: go
 go: "1.10"
-addons:
-  postgresql: "10"
-  apt:
-    packages:
-    - postgresql-10
-    - postgresql-client-10
-env:
-  global:
-  - PGPORT=5432
 services:
   - docker
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ dist: trusty
 sudo: required
 language: go
 go: "1.10"
+addons:
+  postgresql: "9.6"
 services:
   - docker
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ dist: trusty
 sudo: required
 language: go
 go: "1.10"
+addons:
+  postgresql: "10"
 services:
   - docker
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ addons:
     packages:
     - postgresql-10
     - postgresql-client-10
+env:
+  global:
+  - PGPORT=5432
 services:
   - docker
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ language: go
 go: "1.10"
 addons:
   postgresql: "10"
+  apt:
+    packages:
+    - postgresql-10
+    - postgresql-client-10
 services:
   - docker
   - postgresql

--- a/gauges/dead_rows.go
+++ b/gauges/dead_rows.go
@@ -8,7 +8,7 @@ import (
 
 var tableDeadRowsQuery = `
 	SELECT relname
-		 , coalesce(n_dead_tup, 0)::float as n_dead_tup
+	     , coalesce(n_dead_tup, 0) as n_dead_tup
 	  FROM pg_stat_user_tables
 `
 
@@ -43,7 +43,7 @@ func (g *Gauges) TableDeadRows() *prometheus.GaugeVec {
 }
 
 var databaseDeadRowsQuery = `
-	SELECT sum(coalesce(n_dead_tup, 0))::float as n_dead_tup
+	SELECT sum(coalesce(n_dead_tup, 0)) as n_dead_tup
 	  FROM pg_stat_user_tables
 `
 

--- a/gauges/dead_rows.go
+++ b/gauges/dead_rows.go
@@ -1,0 +1,57 @@
+package gauges
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var tableDeadRowsQuery = `
+	SELECT relname
+		 , coalesce(n_dead_tup, 0) as n_dead_tup
+	  FROM pg_stat_user_tables
+`
+
+type tableDeadRows struct {
+	Table      string  `db:"relname"`
+	DeadTuples float64 `db:"n_dead_tup"`
+}
+
+func (g *Gauges) TableDeadRows() *prometheus.GaugeVec {
+	var gauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:        "postgresql_table_dead_rows",
+			Help:        "Number of dead rows in table",
+			ConstLabels: g.labels,
+		},
+		[]string{"table"},
+	)
+	go func() {
+		for {
+			var tableDeadRows []tableDeadRows
+			if err := g.query(tableDeadRowsQuery, &tableDeadRows, emptyParams); err == nil {
+				for _, table := range tableDeadRows {
+					gauge.With(prometheus.Labels{
+						"table": table.Table,
+					}).Set(table.DeadTuples)
+				}
+			}
+			time.Sleep(g.interval)
+		}
+	}()
+	return gauge
+}
+
+var databaseDeadRowsQuery = `
+	SELECT sum(coalesce(n_dead_tup, 0)) as n_dead_tup
+	  FROM pg_stat_user_tables
+`
+
+func (g *Gauges) DatabaseDeadRows() prometheus.Gauge {
+	return g.new(
+		prometheus.GaugeOpts{
+			Name:        "postgresql_database_dead_rows",
+			Help:        "Number of dead rows in database",
+			ConstLabels: g.labels,
+		}, databaseDeadRowsQuery)
+}

--- a/gauges/dead_rows.go
+++ b/gauges/dead_rows.go
@@ -8,7 +8,7 @@ import (
 
 var tableDeadRowsQuery = `
 	SELECT relname
-		 , coalesce(n_dead_tup, 0) as n_dead_tup
+		 , coalesce(n_dead_tup, 0)::float as n_dead_tup
 	  FROM pg_stat_user_tables
 `
 
@@ -43,7 +43,7 @@ func (g *Gauges) TableDeadRows() *prometheus.GaugeVec {
 }
 
 var databaseDeadRowsQuery = `
-	SELECT sum(coalesce(n_dead_tup, 0)) as n_dead_tup
+	SELECT sum(coalesce(n_dead_tup, 0))::float as n_dead_tup
 	  FROM pg_stat_user_tables
 `
 

--- a/gauges/dead_rows.go
+++ b/gauges/dead_rows.go
@@ -17,6 +17,7 @@ type tableDeadRows struct {
 	DeadTuples float64 `db:"n_dead_tup"`
 }
 
+// TableDeadRows returns the estimated number of dead rows of a given table
 func (g *Gauges) TableDeadRows() *prometheus.GaugeVec {
 	var gauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -47,6 +48,7 @@ var databaseDeadRowsQuery = `
 	  FROM pg_stat_user_tables
 `
 
+// DatabaseDeadRows returns the sum of estimated number of dead rows of all tables in a database
 func (g *Gauges) DatabaseDeadRows() prometheus.Gauge {
 	return g.new(
 		prometheus.GaugeOpts{

--- a/gauges/dead_rows_test.go
+++ b/gauges/dead_rows_test.go
@@ -8,7 +8,9 @@ import (
 
 func TestTableDeadRows(t *testing.T) {
 	var assert = assert.New(t)
-	_, gauges, close := prepare(t)
+	db, gauges, close := prepare(t)
+	_, err := db.Exec("CREATE TABLE IF NOT EXISTS deadrowstable(id bigint)")
+	assert.NoError(err)
 	defer close()
 	var metrics = evaluate(t, gauges.TableDeadRows())
 	assert.True(len(metrics) > 0)
@@ -17,7 +19,9 @@ func TestTableDeadRows(t *testing.T) {
 
 func TestDatabaseDeadRows(t *testing.T) {
 	var assert = assert.New(t)
-	_, gauges, close := prepare(t)
+	db, gauges, close := prepare(t)
+	_, err := db.Exec("CREATE TABLE IF NOT EXISTS deadrowstable(id bigint)")
+	assert.NoError(err)
 	defer close()
 	var metrics = evaluate(t, gauges.DatabaseDeadRows())
 	assert.True(len(metrics) > 0)

--- a/gauges/dead_rows_test.go
+++ b/gauges/dead_rows_test.go
@@ -1,0 +1,25 @@
+package gauges
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTableDeadRows(t *testing.T) {
+	var assert = assert.New(t)
+	_, gauges, close := prepare(t)
+	defer close()
+	var metrics = evaluate(t, gauges.TableDeadRows())
+	assert.True(len(metrics) > 0)
+	assertNoErrs(t, gauges)
+}
+
+func TestDatabaseDeadRows(t *testing.T) {
+	var assert = assert.New(t)
+	_, gauges, close := prepare(t)
+	defer close()
+	var metrics = evaluate(t, gauges.DatabaseDeadRows())
+	assert.True(len(metrics) > 0)
+	assertNoErrs(t, gauges)
+}

--- a/gauges/deadtuples_test.go
+++ b/gauges/deadtuples_test.go
@@ -15,7 +15,7 @@ func TestDeadTuples(t *testing.T) {
 	_, err = db.Exec("CREATE EXTENSION IF NOT EXISTS pgstattuple")
 	assert.NoError(err)
 	var metrics = evaluate(t, gauges.DeadTuples())
-	assert.Len(metrics, 1)
+	assert.True(len(metrics) > 0)
 	for _, m := range metrics {
 		assert.Equal(0.0, m.Value)
 	}

--- a/main.go
+++ b/main.go
@@ -107,5 +107,7 @@ func watch(db *sql.DB, reg prometheus.Registerer, name string) {
 	reg.MustRegister(gauges.DatabaseReadingUsage())
 	reg.MustRegister(gauges.DatabaseWritingUsage())
 	reg.MustRegister(gauges.HOTUpdates())
+	reg.MustRegister(gauges.TableDeadRows())
+	reg.MustRegister(gauges.DatabaseDeadRows())
 
 }


### PR DESCRIPTION
This pull request adds two metrics to the exporter

- Table dead rows;
- Database dead rows, that is a sum of table dead rows;

@ContaAzul/sre 