### PR TITLE
Add unvacuumed transactions metric

### DIFF
--- a/gauges/vacuum.go
+++ b/gauges/vacuum.go
@@ -1,0 +1,17 @@
+package gauges
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// UnvacuumedTransactions returns the number of unvacuumed transactions
+func (g *Gauges) UnvacuumedTransactions() prometheus.Gauge {
+	return g.new(
+		prometheus.GaugeOpts{
+			Name:        "postgresql_unvacuumed_transactions_total",
+			Help:        "Number of unvacuumed transactions",
+			ConstLabels: g.labels,
+		},
+		"SELECT age(datfrozenxid) FROM pg_database WHERE datname = current_database()",
+	)
+}

--- a/gauges/vacuum_test.go
+++ b/gauges/vacuum_test.go
@@ -1,0 +1,17 @@
+package gauges
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnvacuumedTransactions(t *testing.T) {
+	var assert = assert.New(t)
+	_, gauges, close := prepare(t)
+	defer close()
+	var metrics = evaluate(t, gauges.UnvacuumedTransactions())
+	assert.Len(metrics, 1)
+	assertGreaterThan(t, 0, metrics[0])
+	assertNoErrs(t, gauges)
+}

--- a/main.go
+++ b/main.go
@@ -111,5 +111,5 @@ func watch(db *sql.DB, reg prometheus.Registerer, name string) {
 	reg.MustRegister(gauges.HOTUpdates())
 	reg.MustRegister(gauges.TableDeadRows())
 	reg.MustRegister(gauges.DatabaseDeadRows())
-
+	reg.MustRegister(gauges.UnvacuumedTransactions())
 }


### PR DESCRIPTION
Add a new metric that returns the number of unvacuumed transactions per database.

Sample output:
```
# HELP postgresql_unvacuumed_transactions_total Number of unvacuumed transactions
# TYPE postgresql_unvacuumed_transactions_total gauge
postgresql_unvacuumed_transactions_total{database_name="postgres"} 6.225869e+06
```

refs https://github.com/ContaAzul/blackops/issues/1995
@ContaAzul/sre 