### PR TITLE
 Add last time (auto)vacuum ran metrics

### DIFF
--- a/gauges/gauge_test.go
+++ b/gauges/gauge_test.go
@@ -64,6 +64,15 @@ func assertGreaterThan(t *testing.T, expected float64, m Metric) {
 	)
 }
 
+func assertEqual(t *testing.T, expected float64, m Metric) {
+	var assert = assert.New(t)
+	assert.Equal(
+		expected,
+		m.Value,
+		"%s should be equal to %v: %v", m.Name, expected, m.Value,
+	)
+}
+
 func prepare(t *testing.T) (*sql.DB, *Gauges, func()) {
 	var db = connect(t)
 	var gauges = New("test", db, 1*time.Minute, 1*time.Second)

--- a/gauges/vacuum.go
+++ b/gauges/vacuum.go
@@ -1,6 +1,8 @@
 package gauges
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -14,4 +16,81 @@ func (g *Gauges) UnvacuumedTransactions() prometheus.Gauge {
 		},
 		"SELECT age(datfrozenxid) FROM pg_database WHERE datname = current_database()",
 	)
+}
+
+type tableVacuum struct {
+	Name           string  `db:"relname"`
+	LastVacuumTime float64 `db:"last_vacuum_time"`
+}
+
+// LastTimeVacuumRan returns the last time in seconds at which a table
+// was manually vacuumed (not counting VACUUM FULL)
+func (g *Gauges) LastTimeVacuumRan() *prometheus.GaugeVec {
+	var gauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:        "postgresql_last_vacuum_seconds",
+			Help:        "Last time in seconds at which a table was manually vacuumed (not counting VACUUM FULL)",
+			ConstLabels: g.labels,
+		},
+		[]string{"table"},
+	)
+
+	const lastVacuumQuery = `
+		SELECT
+		  relname,
+		  COALESCE(EXTRACT(EPOCH FROM last_vacuum), 0) as last_vacuum_time
+		FROM pg_stat_user_tables
+	`
+
+	go func() {
+		for {
+			var tables []tableVacuum
+			if err := g.query(lastVacuumQuery, &tables, emptyParams); err == nil {
+				for _, table := range tables {
+					gauge.With(prometheus.Labels{
+						"table": table.Name,
+					}).Set(table.LastVacuumTime)
+				}
+			}
+			time.Sleep(g.interval)
+		}
+	}()
+
+	return gauge
+}
+
+// LastTimeAutoVacuumRan returns the last time in seconds at which a table
+// was vacuumed by the autovacuum daemon
+func (g *Gauges) LastTimeAutoVacuumRan() *prometheus.GaugeVec {
+	var gauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:        "postgresql_last_autovacuum_seconds",
+			Help:        "Last time in seconds at which a table was vacuumed by the autovacuum daemon",
+			ConstLabels: g.labels,
+		},
+		[]string{"table"},
+	)
+
+	const lastAutoVacuumQuery = `
+		SELECT
+		  relname,
+		  COALESCE(EXTRACT(EPOCH FROM last_autovacuum), 0) as last_vacuum_time
+		FROM pg_stat_user_tables
+	`
+
+	go func() {
+		for {
+			var tables []tableVacuum
+			if err := g.query(lastAutoVacuumQuery, &tables, emptyParams); err == nil {
+				for _, table := range tables {
+					gauge.With(prometheus.Labels{
+						"table": table.Name,
+					}).Set(table.LastVacuumTime)
+				}
+			}
+			time.Sleep(g.interval)
+		}
+	}()
+
+	return gauge
 }

--- a/gauges/vacuum_test.go
+++ b/gauges/vacuum_test.go
@@ -15,3 +15,29 @@ func TestUnvacuumedTransactions(t *testing.T) {
 	assertGreaterThan(t, 0, metrics[0])
 	assertNoErrs(t, gauges)
 }
+
+func TestLastTimeVacuumRan(t *testing.T) {
+	var assert = assert.New(t)
+	db, gauges, close := prepare(t)
+	defer close()
+	dropTestTable := createTestTable(t, db)
+	defer dropTestTable()
+
+	var metrics = evaluate(t, gauges.LastTimeVacuumRan())
+	assert.Len(metrics, 1)
+	assertEqual(t, 0, metrics[0])
+	assertNoErrs(t, gauges)
+}
+
+func TestLastTimeAutoVacuumRan(t *testing.T) {
+	var assert = assert.New(t)
+	db, gauges, close := prepare(t)
+	defer close()
+	dropTestTable := createTestTable(t, db)
+	defer dropTestTable()
+
+	var metrics = evaluate(t, gauges.LastTimeAutoVacuumRan())
+	assert.Len(metrics, 1)
+	assertEqual(t, 0, metrics[0])
+	assertNoErrs(t, gauges)
+}

--- a/main.go
+++ b/main.go
@@ -112,4 +112,6 @@ func watch(db *sql.DB, reg prometheus.Registerer, name string) {
 	reg.MustRegister(gauges.TableDeadRows())
 	reg.MustRegister(gauges.DatabaseDeadRows())
 	reg.MustRegister(gauges.UnvacuumedTransactions())
+	reg.MustRegister(gauges.LastTimeVacuumRan())
+	reg.MustRegister(gauges.LastTimeAutoVacuumRan())
 }


### PR DESCRIPTION
Added two new metrics to return vacuum process execution:
- `postgresql_last_autovacuum_seconds`: returns the last time in seconds at which a table was vacuumed by the autovacuum daemon
- `postgresql_last_vacuum_seconds`: returns the last time in seconds at which a table was manually vacuumed (not counting VACUUM FULL)

Sample output:
```
# HELP postgresql_last_autovacuum_seconds Last time in seconds at which a table was vacuumed by the autovacuum daemon
# TYPE postgresql_last_autovacuum_seconds gauge
postgresql_last_autovacuum_seconds{database_name="postgres",table="mytable"} 0
# HELP postgresql_last_vacuum_seconds Last time in seconds at which a table was manually vacuumed (not counting VACUUM FULL)
# TYPE postgresql_last_vacuum_seconds gauge
postgresql_last_vacuum_seconds{database_name="postgres",table="mytable"} 1.531772117054716e+09
```

refs https://github.com/ContaAzul/blackops/issues/1995
@ContaAzul/sre 