### PR TITLE
Add vacuum process running metric

### DIFF
--- a/gauges/vacuum.go
+++ b/gauges/vacuum.go
@@ -98,13 +98,13 @@ func (g *Gauges) LastTimeAutoVacuumRan() *prometheus.GaugeVec {
 }
 
 // VacuumRunningTotal returns the number of backends (including autovacuum worker processes)
-// that is currently running a vacuuming (not include VACUUM FULL).
+// that are currently running a vacuuming (not including VACUUM FULL).
 //
 // This metric is only supported for PostgreSQL 9.6 or newer versions
 func (g *Gauges) VacuumRunningTotal() prometheus.Gauge {
 	var gaugeOpts = prometheus.GaugeOpts{
 		Name:        "postgresql_vacuum_running_total",
-		Help:        "Number of backends (including autovacuum worker processes) that is currently vacuuming",
+		Help:        "Number of backends (including autovacuum worker processes) currently vacuuming",
 		ConstLabels: g.labels,
 	}
 

--- a/gauges/vacuum_test.go
+++ b/gauges/vacuum_test.go
@@ -41,3 +41,14 @@ func TestLastTimeAutoVacuumRan(t *testing.T) {
 	assertEqual(t, 0, metrics[0])
 	assertNoErrs(t, gauges)
 }
+
+func TestVacuumRunningTotal(t *testing.T) {
+	var assert = assert.New(t)
+	_, gauges, close := prepare(t)
+	defer close()
+
+	var metrics = evaluate(t, gauges.VacuumRunningTotal())
+	assert.Len(metrics, 1)
+	assertEqual(t, 0, metrics[0])
+	assertNoErrs(t, gauges)
+}

--- a/main.go
+++ b/main.go
@@ -115,4 +115,5 @@ func watch(db *sql.DB, reg prometheus.Registerer, name string) {
 	reg.MustRegister(gauges.UnvacuumedTransactions())
 	reg.MustRegister(gauges.LastTimeVacuumRan())
 	reg.MustRegister(gauges.LastTimeAutoVacuumRan())
+	reg.MustRegister(gauges.VacuumRunningTotal())
 }


### PR DESCRIPTION
Added a new metric to return the number of backends (including autovacuum worker processes) that is currently running a vacuuming. This is a metric that only works on PostgreSQL 9.6 or higher

Sample output:
```
# HELP postgresql_vacuum_running_total Number of backends (including autovacuum worker processes) that is currently vacuuming
# TYPE postgresql_vacuum_running_total gauge
postgresql_vacuum_running_total{database_name="otherdb"} 2
postgresql_vacuum_running_total{database_name="somedb"} 0
```

refs https://github.com/ContaAzul/blackops/issues/1995
@ContaAzul/sre 