### PR TITLE
Refactory deadlock metric

### DIFF
--- a/gauges/basics.go
+++ b/gauges/basics.go
@@ -59,24 +59,3 @@ func (g *Gauges) TempFiles() prometheus.Gauge {
 		"SELECT temp_files FROM pg_stat_database WHERE datname = current_database()",
 	)
 }
-
-func (g *Gauges) Deadlocks() prometheus.Gauge {
-	return g.new(
-		prometheus.GaugeOpts{
-			Name:        "postgresql_deadlocks",
-			Help:        "Number of deadlocks in the last 2m",
-			ConstLabels: g.labels,
-		},
-		`
-			SELECT count(*) FROM pg_locks bl
-			JOIN pg_stat_activity a
-			ON a.pid = bl.pid JOIN pg_locks kl
-			ON kl.transactionid = bl.transactionid
-			AND kl.pid != bl.pid JOIN pg_stat_activity ka
-			ON ka.pid = kl.pid WHERE NOT bl.granted
-			AND (ka.query_start >= (now() - interval '2 minutes')
-			OR a.query_start >= (now() - interval '2 minutes'))
-			AND a.datname = current_database()
-		`,
-	)
-}

--- a/gauges/basics_test.go
+++ b/gauges/basics_test.go
@@ -26,16 +26,6 @@ func TestSize(t *testing.T) {
 	assertNoErrs(t, gauges)
 }
 
-func TestDeadlocks(t *testing.T) {
-	var assert = assert.New(t)
-	_, gauges, close := prepare(t)
-	defer close()
-	var metrics = evaluate(t, gauges.Deadlocks())
-	assert.Len(metrics, 1)
-	assertGreaterThan(t, -1, metrics[0])
-	assertNoErrs(t, gauges)
-}
-
 func TestTempSize(t *testing.T) {
 	var assert = assert.New(t)
 	_, gauges, close := prepare(t)

--- a/gauges/locks.go
+++ b/gauges/locks.go
@@ -69,3 +69,15 @@ func (g *Gauges) NotGrantedLocks() prometheus.Gauge {
 		`,
 	)
 }
+
+// DeadLocks returns the number of deadlocks detected on the database
+func (g *Gauges) DeadLocks() prometheus.Gauge {
+	return g.new(
+		prometheus.GaugeOpts{
+			Name:        "postgresql_deadlocks_total",
+			Help:        "Number of deadlocks detected on the database",
+			ConstLabels: g.labels,
+		},
+		"SELECT deadlocks FROM pg_stat_database WHERE datname = current_database()",
+	)
+}

--- a/gauges/locks.go
+++ b/gauges/locks.go
@@ -6,24 +6,24 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type lockCountWithMode struct {
+type locks struct {
 	Mode  string  `db:"mode"`
 	Count float64 `db:"count"`
 }
 
-// Locks returns the number of locks by mode
+// Locks returns the number of active locks on the database by mode
 func (g *Gauges) Locks() *prometheus.GaugeVec {
 	var gauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name:        "postgresql_lock_count",
-			Help:        "Number of locks by mode",
+			Name:        "postgresql_locks_total",
+			Help:        "Number of active locks on the database by mode",
 			ConstLabels: g.labels,
 		},
 		[]string{"mode"},
 	)
 	go func() {
 		for {
-			var locks []lockCountWithMode
+			var locks []locks
 			if err := g.query(
 				`
 					SELECT mode, count(*) as count
@@ -49,12 +49,12 @@ func (g *Gauges) Locks() *prometheus.GaugeVec {
 	return gauge
 }
 
-// NotGrantedLocks returns the number of not granted locks
+// NotGrantedLocks returns the number of not granted locks on the database
 func (g *Gauges) NotGrantedLocks() prometheus.Gauge {
 	return g.new(
 		prometheus.GaugeOpts{
-			Name:        "postgresql_not_granted_locks",
-			Help:        "Number of not granted locks",
+			Name:        "postgresql_not_granted_locks_total",
+			Help:        "Number of not granted locks on the database",
 			ConstLabels: g.labels,
 		},
 		`

--- a/gauges/locks_test.go
+++ b/gauges/locks_test.go
@@ -25,3 +25,13 @@ func TestNotGrantedLocks(t *testing.T) {
 	assertGreaterThan(t, -1, metrics[0])
 	assertNoErrs(t, gauges)
 }
+
+func TestDeadLocks(t *testing.T) {
+	var assert = assert.New(t)
+	_, gauges, close := prepare(t)
+	defer close()
+	var metrics = evaluate(t, gauges.DeadLocks())
+	assert.Len(metrics, 1)
+	assertGreaterThan(t, -1, metrics[0])
+	assertNoErrs(t, gauges)
+}

--- a/main.go
+++ b/main.go
@@ -91,6 +91,7 @@ func watch(db *sql.DB, reg prometheus.Registerer, name string) {
 	reg.MustRegister(gauges.IndexBlocksRead())
 	reg.MustRegister(gauges.Locks())
 	reg.MustRegister(gauges.NotGrantedLocks())
+	reg.MustRegister(gauges.DeadLocks())
 	reg.MustRegister(gauges.ReplicationDelayInSeconds())
 	reg.MustRegister(gauges.ReplicationDelayInBytes())
 	reg.MustRegister(gauges.ReplicationStatus())

--- a/main.go
+++ b/main.go
@@ -83,7 +83,6 @@ func watch(db *sql.DB, reg prometheus.Registerer, name string) {
 	reg.MustRegister(gauges.ScheduledCheckpoints())
 	reg.MustRegister(gauges.BuffersMaxWrittenClean())
 	reg.MustRegister(gauges.BuffersWritten())
-	reg.MustRegister(gauges.Deadlocks())
 	reg.MustRegister(gauges.DeadTuples())
 	reg.MustRegister(gauges.HeapBlocksHit())
 	reg.MustRegister(gauges.HeapBlocksRead())


### PR DESCRIPTION
Refactored the deadlock metric. We can use the column `deadlocks` from `pg_stat_database` instead of that old query. 

I also followed prometheus name and labeling best practices and fix lock related metrics.

Sample output:
```
# HELP postgresql_deadlocks_total Number of deadlocks detected on the database
# TYPE postgresql_deadlocks_total gauge
postgresql_deadlocks_total{database_name="other"} 24
postgresql_deadlocks_total{database_name="dba"} 0
```

refs ContaAzul/blackops#1995
@ContaAzul/sre