### PR TITLE
Slow Queries: Removing superuser requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can add as many database connections as you like to the
 ./postgresql_exporter -config=my/config.yml
 ```
 
-Some stats are hidden from normal database users, so you must grant acess to that:
+By default some stat views like pg_stat_statements and pg_stat_activity doesn't allow viewing queries run by other users, unless you are a database superuser. Since you probably don't want monitoring to run as a superuser, you can setup, in a AWS RDS instance, a separate monitoring user like this:
 
 ```sql
 GRANT pg_monitor TO my_monitor_user;

--- a/README.md
+++ b/README.md
@@ -2,11 +2,19 @@
 
 A Prometheus exporter for some postgresql metrics.
 
+## Getting Started
+
 You can add as many database connections as you like to the
 `config.yml` file, and run it with:
 
 ```console
 ./postgresql_exporter -config=my/config.yml
+```
+
+Some stats are hidden from normal database users, so you must grant acess to that:
+
+```sql
+GRANT pg_monitor to my_monitor_user;
 ```
 
 Then you can add hostname:9111 to the prometheus scrapes config:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can add as many database connections as you like to the
 Some stats are hidden from normal database users, so you must grant acess to that:
 
 ```sql
-GRANT pg_monitor to my_monitor_user;
+GRANT pg_monitor TO my_monitor_user;
 ```
 
 Then you can add hostname:9111 to the prometheus scrapes config:

--- a/gauges/slow_queries.go
+++ b/gauges/slow_queries.go
@@ -28,10 +28,6 @@ func (g *Gauges) SlowestQueries() *prometheus.GaugeVec {
 		},
 		[]string{"query"},
 	)
-	if !g.isSuperuser {
-		log.Warn("postgresql_slowest_queries disabled because it requires a superuser to see queries from other users")
-		return gauge
-	}
 	if !g.hasExtension("pg_stat_statements") {
 		log.Warn("postgresql_slowest_queries disabled because pg_stat_statements extension is not installed")
 		return gauge


### PR DESCRIPTION
To collect slow queries without a superuser you may grant access to pg_monitor role.
This pull request remove the superuser requirement from slow queries and add a section "Getting Started" to README.md with a command that grants access to pg_monitor role;

@ContaAzul/sre 