### PR TITLE
 Fix database (dead|live) tuples queries

### DIFF
--- a/gauges/deadtuples.go
+++ b/gauges/deadtuples.go
@@ -20,11 +20,13 @@ func (g *Gauges) DeadTuples() *prometheus.GaugeVec {
 	}, []string{"table"})
 
 	if !g.hasExtension("pgstattuple") {
-		log.Warn("postgresql_dead_tuples_pct disabled because pgstattuple extension is not installed")
+		log.WithField("db", g.name).
+			Warn("postgresql_dead_tuples_pct disabled because pgstattuple extension is not installed")
 		return gauge
 	}
 	if !g.hasPermissionToExecutePgStatTuple() {
-		log.Warn("postgresql_dead_tuples_pct disabled because user doesn't have permission to use pgstattuple functions")
+		log.WithField("db", g.name).
+			Warn("postgresql_dead_tuples_pct disabled because user doesn't have permission to use pgstattuple functions")
 		return gauge
 	}
 
@@ -56,7 +58,7 @@ func (g *Gauges) DeadTuples() *prometheus.GaugeVec {
 
 func (g *Gauges) hasPermissionToExecutePgStatTuple() bool {
 	if _, err := g.db.Exec("SELECT 1 FROM pgstattuple('pg_class')"); err != nil {
-		log.WithError(err).Error("failed to execute pgstattuple function")
+		log.WithField("db", g.name).WithError(err).Error("failed to execute pgstattuple function")
 		return false
 	}
 	return true

--- a/gauges/gauge.go
+++ b/gauges/gauge.go
@@ -152,7 +152,7 @@ func (g *Gauges) queryWithTimeout(
 func (g *Gauges) version() string {
 	var version string
 	if err := g.db.QueryRow("show server_version").Scan(&version); err != nil {
-		log.WithError(err).Error("failed to get postgresql version, assuming 9.6.0")
+		log.WithField("db", g.name).WithError(err).Error("failed to get postgresql version, assuming 9.6.0")
 		return "9.6.0"
 	}
 	return version

--- a/gauges/slow_queries.go
+++ b/gauges/slow_queries.go
@@ -29,11 +29,13 @@ func (g *Gauges) SlowestQueries() *prometheus.GaugeVec {
 		[]string{"query"},
 	)
 	if !g.hasExtension("pg_stat_statements") {
-		log.Warn("postgresql_slowest_queries disabled because pg_stat_statements extension is not installed")
+		log.WithField("db", g.name).
+			Warn("postgresql_slowest_queries disabled because pg_stat_statements extension is not installed")
 		return gauge
 	}
 	if !g.hasSharedPreloadLibrary("pg_stat_statements") {
-		log.Warn("postgresql_slowest_queries disabled because pg_stat_statements is not on shared_preload_libraries")
+		log.WithField("db", g.name).
+			Warn("postgresql_slowest_queries disabled because pg_stat_statements is not on shared_preload_libraries")
 		return gauge
 	}
 	go func() {

--- a/gauges/table_rows.go
+++ b/gauges/table_rows.go
@@ -50,7 +50,7 @@ func (g *Gauges) DatabaseDeadRows() prometheus.Gauge {
 			Help:        "Estimated number of dead rows in a database",
 			ConstLabels: g.labels,
 		},
-		"SELECT sum(coalesce(n_dead_tup, 0)) as n_dead_tup FROM pg_stat_user_tables",
+		"SELECT coalesce(sum(n_dead_tup), 0) as n_dead_tup FROM pg_stat_user_tables",
 	)
 }
 
@@ -98,6 +98,6 @@ func (g *Gauges) DatabaseLiveRows() prometheus.Gauge {
 			Help:        "Estimated number of live rows in a database",
 			ConstLabels: g.labels,
 		},
-		"SELECT sum(coalesce(n_live_tup, 0)) as n_live_tup FROM pg_stat_user_tables",
+		"SELECT coalesce(sum(n_live_tup), 0) as n_live_tup FROM pg_stat_user_tables",
 	)
 }

--- a/gauges/vacuum.go
+++ b/gauges/vacuum.go
@@ -113,7 +113,8 @@ func (g *Gauges) VacuumRunningTotal() prometheus.Gauge {
 	`
 
 	if !postgres.Version(g.version()).Is96Or10() {
-		log.Warn("postgresql_vacuum_running_total disabled because it's only supported for PostgreSQL 9.6 or newer versions")
+		log.WithField("db", g.name).
+			Warn("postgresql_vacuum_running_total disabled because it's only supported for PostgreSQL 9.6 or newer versions")
 		return prometheus.NewGauge(gaugeOpts)
 	}
 	return g.new(gaugeOpts, vacuumRunningQuery)


### PR DESCRIPTION
Fixed the queries that returns the sum of estimated number of (dead|live) rows of all tables in a database, to avoid this error:
```
timestamp=2018-07-26T17:35:05.53238147Z level=error message="query failed" db=bank-accounting-integrator error="sql: Scan error on column index 0: converting driver.Value type <nil> (\"<nil>\") to a float64: invalid syntax" query="SELECT sum(coalesce(n_dead_tup, 0)) as n_dead_tup ..."
```
Also, i added the db info as a field in warnings logs to help identity where the warning occurred:
```
timestamp=2018-07-26T17:34:35.693974798Z level=warn message="postgresql_dead_tuples_pct disabled because pgstattuple extension is not installed"
```

refs https://github.com/ContaAzul/blackops/issues/2021
@ContaAzul/sre 