### PR TITLE
Reseting gauge on metrics

### DIFF
--- a/gauges/backends.go
+++ b/gauges/backends.go
@@ -55,6 +55,7 @@ func (g *Gauges) BackendsByState() *prometheus.GaugeVec {
 	`
 
 	go func() {
+		gauge.Reset()
 		for {
 			var backendsByState []backendsByState
 			if err := g.query(backendsByStateQuery, &backendsByState, emptyParams); err == nil {
@@ -109,6 +110,7 @@ func (g *Gauges) BackendsByWaitEventType() *prometheus.GaugeVec {
 	)
 
 	go func() {
+		gauge.Reset()
 		for {
 			var backendsByWaitEventType []backendsByWaitEventType
 			if err := g.query(g.backendsByWaitEventTypeQuery(),

--- a/gauges/backends.go
+++ b/gauges/backends.go
@@ -55,8 +55,8 @@ func (g *Gauges) BackendsByState() *prometheus.GaugeVec {
 	`
 
 	go func() {
-		gauge.Reset()
 		for {
+			gauge.Reset()
 			var backendsByState []backendsByState
 			if err := g.query(backendsByStateQuery, &backendsByState, emptyParams); err == nil {
 				for _, row := range backendsByState {
@@ -110,8 +110,8 @@ func (g *Gauges) BackendsByWaitEventType() *prometheus.GaugeVec {
 	)
 
 	go func() {
-		gauge.Reset()
 		for {
+			gauge.Reset()
 			var backendsByWaitEventType []backendsByWaitEventType
 			if err := g.query(g.backendsByWaitEventTypeQuery(),
 				&backendsByWaitEventType, emptyParams); err == nil {

--- a/gauges/locks.go
+++ b/gauges/locks.go
@@ -23,6 +23,7 @@ func (g *Gauges) Locks() *prometheus.GaugeVec {
 	)
 	go func() {
 		for {
+			gauge.Reset()
 			var locks []locks
 			if err := g.query(
 				`


### PR DESCRIPTION
After some value is setted to metrics `postgresql_backends_by_wait_event_type_total`, `postgresql_backends_by_state_total` and `postgresql_locks_total`, the value is not updated if the query returns
no rows.

To fix that, the gauge is reseted every time when the query is executed, thus grants
that the old value cleared.