### PR TITLE
Filter slow queries per database

### DIFF
--- a/gauges/slow_queries.go
+++ b/gauges/slow_queries.go
@@ -11,6 +11,7 @@ import (
 const slowQueriesQuery = `
 	SELECT total_time, query
 	FROM pg_stat_statements
+	WHERE dbid = (SELECT datid FROM pg_stat_database WHERE datname = current_database())
 	ORDER BY total_time desc limit 10
 `
 


### PR DESCRIPTION
We forgot to filter slow queries per database making the metrics show all queries instead of only queries for a given database