### PR TITLE
Add Backends by user and client address metric

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -13,8 +13,8 @@
     ".",
     "handlers/logfmt"
   ]
-  revision = "0296d6eb16bb28f8a0c55668affcf4876dc269be"
-  version = "v1.0.0"
+  revision = "941dea75d3ebfbdd905a5d8b7b232965c5e5c684"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
@@ -41,13 +41,13 @@
   version = "v1.2.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/jmoiron/sqlx"
   packages = [
     ".",
     "reflectx"
   ]
-  revision = "0dae4fefe7c0e190f7b5a78dac28a1c82cc8d849"
+  revision = "d161d7a76b5661016ad0b085869f77fd410f3e6a"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
@@ -56,13 +56,13 @@
   revision = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
 
 [[projects]]
+  branch = "master"
   name = "github.com/lib/pq"
   packages = [
     ".",
     "oid"
   ]
-  revision = "4ded0e9383f75c197b3a2aaa6d590ac52df6fd79"
-  version = "v1.0.0"
+  revision = "9eb73efc1fcc404148b56765b0d3f61d9a5ef8ee"
 
 [[projects]]
   name = "github.com/matttproud/golang_protobuf_extensions"
@@ -86,10 +86,11 @@
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
+    "prometheus/internal",
     "prometheus/promhttp"
   ]
-  revision = "c5b7fccd204277076155f10851dad72b76a49317"
-  version = "v0.8.0"
+  revision = "1cafe34db7fdec6022e17e00e1c1ea501022f3e4"
+  version = "v0.9.0"
 
 [[projects]]
   branch = "master"
@@ -105,7 +106,7 @@
     "internal/bitbucket.org/ww/goautoneg",
     "model"
   ]
-  revision = "c7de2306084e37d54b8be01f3541a8464345e9a5"
+  revision = "7e9e6cabbd393fc208072eedef99188d0ce788b6"
 
 [[projects]]
   branch = "master"
@@ -116,7 +117,7 @@
     "nfs",
     "xfs"
   ]
-  revision = "418d78d0b9a7b7de3a6bbc8a23def624cc977bb2"
+  revision = "185b4288413d2a0dd0806f78c90dde719829e5ae"
 
 [[projects]]
   name = "github.com/stretchr/testify"

--- a/gauges/backends.go
+++ b/gauges/backends.go
@@ -82,7 +82,7 @@ type backendsByUserAndClientAddress struct {
 func (g *Gauges) BackendsByUserAndClientAddress() *prometheus.GaugeVec {
 	var gauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name:        "postgresql_backends_by_state_total",
+			Name:        "postgresql_backends_by_user_total",
 			Help:        "Number of backends currently connected to database by user and client address",
 			ConstLabels: g.labels,
 		},
@@ -93,7 +93,7 @@ func (g *Gauges) BackendsByUserAndClientAddress() *prometheus.GaugeVec {
 		SELECT
 		  COUNT(*) AS total,
 		  usename,
-		  COALESCE(client_addr, '127.0.0.1') AS client_addr
+		  COALESCE(client_addr, '::1') AS client_addr
 		FROM pg_stat_activity
 		WHERE datname = current_database()
 		GROUP BY usename, client_addr

--- a/gauges/backends_test.go
+++ b/gauges/backends_test.go
@@ -38,6 +38,18 @@ func TestBackendsByState(t *testing.T) {
 	assertNoErrs(t, gauges)
 }
 
+func TestBackendsByUserAndClientAddress(t *testing.T) {
+	var assert = assert.New(t)
+	_, gauges, close := prepare(t)
+	defer close()
+	var metrics = evaluate(t, gauges.BackendsByUserAndClientAddress())
+	assert.True(len(metrics) > 0)
+	for _, m := range metrics {
+		assertGreaterThan(t, 0, m)
+	}
+	assertNoErrs(t, gauges)
+}
+
 // TODO: somehow set a waiting connections to proper test this
 func TestBackendsByWaitEventType(t *testing.T) {
 	var assert = assert.New(t)

--- a/gauges/basics.go
+++ b/gauges/basics.go
@@ -6,11 +6,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// Up returns if database is up and accepting connections
 func (g *Gauges) Up() prometheus.Gauge {
 	var gauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name:        "postgresql_up",
-			Help:        "Dabatase is up and accepting connections",
+			Help:        "Database is up and accepting connections",
 			ConstLabels: g.labels,
 		},
 	)
@@ -27,6 +28,7 @@ func (g *Gauges) Up() prometheus.Gauge {
 	return gauge
 }
 
+// Size returns the database size in bytes
 func (g *Gauges) Size() prometheus.Gauge {
 	return g.new(
 		prometheus.GaugeOpts{
@@ -38,22 +40,24 @@ func (g *Gauges) Size() prometheus.Gauge {
 	)
 }
 
+// TempSize returns the database total amount of data written to temporary files in bytes
 func (g *Gauges) TempSize() prometheus.Gauge {
 	return g.new(
 		prometheus.GaugeOpts{
 			Name:        "postgresql_temp_bytes",
-			Help:        "Temp size in bytes",
+			Help:        "Database total amount of data written to temporary files in bytes",
 			ConstLabels: g.labels,
 		},
 		"SELECT temp_bytes FROM pg_stat_database WHERE datname = current_database()",
 	)
 }
 
+// TempFiles returns the number of temporary files created by queries in this database.
 func (g *Gauges) TempFiles() prometheus.Gauge {
 	return g.new(
 		prometheus.GaugeOpts{
 			Name:        "postgresql_temp_files",
-			Help:        "Count of temp files",
+			Help:        "Number of temporary files created by queries in this database.",
 			ConstLabels: g.labels,
 		},
 		"SELECT temp_files FROM pg_stat_database WHERE datname = current_database()",

--- a/main.go
+++ b/main.go
@@ -78,6 +78,7 @@ func watch(db *sql.DB, reg prometheus.Registerer, name string) {
 	reg.MustRegister(gauges.ConnectedBackends())
 	reg.MustRegister(gauges.MaxBackends())
 	reg.MustRegister(gauges.BackendsByState())
+	reg.MustRegister(gauges.BackendsByUserAndClientAddress())
 	reg.MustRegister(gauges.BackendsByWaitEventType())
 	reg.MustRegister(gauges.RequestedCheckpoints())
 	reg.MustRegister(gauges.ScheduledCheckpoints())


### PR DESCRIPTION
Added a new metric to the number of backends currently connected to database by user and client address

Sample output:
```
# HELP postgresql_backends_by_user_total Number of backends currently connected to database by user and client address
# TYPE postgresql_backends_by_user_total gauge
postgresql_backends_by_user_total{client_addr="::1",database_name="dba",user="contaazul"} 1
postgresql_backends_by_user_total{client_addr="::1",database_name="dba",user="dnicoleti"} 1
```

refs https://github.com/ContaAzul/blackops/issues/2115
@ContaAzul/sre 