### PR TITLE
Only check replication delay if is in recovery mode

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -21,12 +21,12 @@
   version = "v1.1.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:c0bec5f9b98d0bc872ff5e834fac186b807b656683bd29cb82fb207a1513fabb"
+  digest = "1:0d3deb8a6da8ffba5635d6fb1d2144662200def6c9d82a35a6d05d6c2d4a48f9"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
   pruneopts = ""
-  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+  revision = "4b2b341e8d7715fae06375aa633dbb6e91b3fb46"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
@@ -45,12 +45,12 @@
   version = "v0.4.0"
 
 [[projects]]
-  digest = "1:3dd078fda7500c341bc26cfbc6c6a34614f295a2457149fc1045cab767cbcf18"
+  digest = "1:529d738b7976c3848cae5cf3a8036440166835e389c1f617af701eeb12a0518d"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
   pruneopts = ""
-  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
-  version = "v1.2.0"
+  revision = "b5d812f8a3706043e23a9cd5babf2e5423744d30"
+  version = "v1.3.1"
 
 [[projects]]
   digest = "1:4611e727460d3634059cbe6e0a4799aaeb426ef8150e3b26056c83e1106831c4"
@@ -73,14 +73,15 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:bc36cd980d0069137800b505af4937c6109f4dc7cefe39d7c2efc7c8d51528d6"
+  digest = "1:4baf03221e12922dc224a470f9e1a36d8c7564af81fd6427924383232d92b20c"
   name = "github.com/lib/pq"
   packages = [
     ".",
     "oid",
+    "scram",
   ]
   pruneopts = ""
-  revision = "9eb73efc1fcc404148b56765b0d3f61d9a5ef8ee"
+  revision = "2ff3cb3adc01768e0a552b3a02575a6df38a9bea"
 
 [[projects]]
   digest = "1:63722a4b1e1717be7b98fc686e0b30d5e7f734b9e93d7dee86293b6deab7ea28"
@@ -120,15 +121,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3fa49ea0332c644e4d4ce3864d8eee2cc6c858cb52bf935e32c28d194a0f2bfa"
+  digest = "1:cd67319ee7536399990c4b00fae07c3413035a53193c644549a676091507cadc"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
   pruneopts = ""
-  revision = "f287a105a20ec685d797f65cd0ce8fbeaef42da1"
+  revision = "fd36f4220a901265f90734c3183c5f0c91daa0b8"
 
 [[projects]]
-  branch = "master"
-  digest = "1:43465e4460e21f6462de4dbfdd864a2a48b743b25175d436932fb3e09765c937"
+  digest = "1:acd87a73c6a6f2d61ad04822d68b233a5c12f5b72aef3db0985f90680e9ae8f0"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
@@ -136,20 +136,19 @@
     "model",
   ]
   pruneopts = ""
-  revision = "2998b132700a7d019ff618c06a234b47c1f3f681"
+  revision = "1ba88736f028e37bc17328369e94a537ae9e0234"
+  version = "v0.4.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:b9a435d988632d00a70882d2754f2a59468d4be56fd62022ab2ca4640fc70c66"
+  digest = "1:8104ddcc08a1fb39322b65c886bf3a94c216b35268c8d3eed158ca0c6615de27"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
-    "internal/util",
-    "nfs",
-    "xfs",
+    "internal/fs",
   ]
   pruneopts = ""
-  revision = "b1a0a9a36d7453ba0f62578b99712f3a6c5f82d1"
+  revision = "5867b95ac084bbfee6ea16595c4e05ab009021da"
 
 [[projects]]
   digest = "1:381bcbeb112a51493d9d998bbba207a529c73dbb49b3fd789e48c63fac1f192c"

--- a/gauges/replication.go
+++ b/gauges/replication.go
@@ -60,7 +60,12 @@ func (g *Gauges) ReplicationDelayInSeconds() prometheus.Gauge {
 			Help:        "Dabatase replication delay in seconds",
 			ConstLabels: g.labels,
 		},
-		"SELECT coalesce(extract(epoch from now() - pg_last_xact_replay_timestamp()), 0) AS replication_delay",
+		`
+			SELECT CASE WHEN pg_is_in_recovery() is true
+			THEN COALESCE(EXTRACT(EPOCH FROM now() - pg_last_xact_replay_timestamp()), 0)
+			ELSE 0
+			END AS replication_delay
+		`,
 	)
 }
 

--- a/gauges/replication.go
+++ b/gauges/replication.go
@@ -51,7 +51,7 @@ func (g *Gauges) StreamingWALs() prometheus.Gauge {
 	)
 }
 
-// ReplicationDelay returns a prometheus gauge for the database replication
+// ReplicationDelayInSeconds returns a prometheus gauge for the database replication
 // lag in seconds
 func (g *Gauges) ReplicationDelayInSeconds() prometheus.Gauge {
 	return g.new(

--- a/gauges/replication_test.go
+++ b/gauges/replication_test.go
@@ -16,7 +16,7 @@ func TestReplicationStatus(t *testing.T) {
 	assertNoErrs(t, gauges)
 }
 
-func TestReplicationDelay(t *testing.T) {
+func TestReplicationDelayInSeconds(t *testing.T) {
 	var assert = assert.New(t)
 	_, gauges, close := prepare(t)
 	defer close()


### PR DESCRIPTION
When a standby server is promoted the function `pg_last_xact_replay_timestamp` still returns a value for last transaction replayed during recovery, but the server is no longer in recovery mode.

> Get time stamp of last transaction replayed during recovery. This is the time at which the commit or abort WAL record for that transaction was generated on the primary. If no transactions have been replayed during recovery, this function returns NULL. Otherwise, if recovery is still in progress this will increase monotonically. **If recovery has completed then this value will remain static at the value of the last transaction applied during that recovery.** When the server has been started normally without recovery the function returns NULL.

Added a verification to check if the server is in recovery mode before getting the value.

@ContaAzul/sre 