### PR TITLE
Add support to PostgreSQL 11+

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,15 +10,15 @@
   revision = "d677fdf2ae1fa75d8111faf17f2d6fcf46dd9af7"
 
 [[projects]]
-  digest = "1:317998b1359366dda9f69cdbd108c39c7b3813a69002246fac4e3548646c1620"
+  digest = "1:ae00e2ff18d31ca63336e52f93bf0d298eda9f35e9504b54ad7640c6845603c0"
   name = "github.com/apex/log"
   packages = [
     ".",
     "handlers/logfmt",
   ]
   pruneopts = ""
-  revision = "941dea75d3ebfbdd905a5d8b7b232965c5e5c684"
-  version = "v1.1.0"
+  revision = "295021f518f737dd0bfdca2c98136517703196b9"
+  version = "v1.1.1"
 
 [[projects]]
   digest = "1:0d3deb8a6da8ffba5635d6fb1d2144662200def6c9d82a35a6d05d6c2d4a48f9"
@@ -45,12 +45,12 @@
   version = "v0.4.0"
 
 [[projects]]
-  digest = "1:529d738b7976c3848cae5cf3a8036440166835e389c1f617af701eeb12a0518d"
+  digest = "1:b852d2b62be24e445fcdbad9ce3015b44c207815d631230dfce3f14e7803f5bf"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
   pruneopts = ""
-  revision = "b5d812f8a3706043e23a9cd5babf2e5423744d30"
-  version = "v1.3.1"
+  revision = "6c65a5562fc06764971b7c5d05c76c75e84bdbf7"
+  version = "v1.3.2"
 
 [[projects]]
   digest = "1:4611e727460d3634059cbe6e0a4799aaeb426ef8150e3b26056c83e1106831c4"
@@ -73,7 +73,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4baf03221e12922dc224a470f9e1a36d8c7564af81fd6427924383232d92b20c"
+  digest = "1:f4216047c24ab66fb757045febd7dac4edc6f4ad9f6c0063d0755d654d04f25e"
   name = "github.com/lib/pq"
   packages = [
     ".",
@@ -81,7 +81,7 @@
     "scram",
   ]
   pruneopts = ""
-  revision = "2ff3cb3adc01768e0a552b3a02575a6df38a9bea"
+  revision = "3427c32cb71afc948325f299f040e53c1dd78979"
 
 [[projects]]
   digest = "1:63722a4b1e1717be7b98fc686e0b30d5e7f734b9e93d7dee86293b6deab7ea28"
@@ -108,7 +108,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:6f218995d6a74636cfcab45ce03005371e682b4b9bee0e5eb0ccfd83ef85364f"
+  digest = "1:d1c6da923f9044766d87a464bfcce4afe9456da4cca84cfe7a6d714dac57ca95"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
@@ -116,8 +116,8 @@
     "prometheus/promhttp",
   ]
   pruneopts = ""
-  revision = "505eaef017263e299324067d40ca2c48f6a2cf50"
-  version = "v0.9.2"
+  revision = "4ab88e80c249ed361d3299e2930427d9ac43ef8d"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -128,7 +128,7 @@
   revision = "fd36f4220a901265f90734c3183c5f0c91daa0b8"
 
 [[projects]]
-  digest = "1:acd87a73c6a6f2d61ad04822d68b233a5c12f5b72aef3db0985f90680e9ae8f0"
+  digest = "1:0f2cee44695a3208fe5d6926076641499c72304e6f015348c9ab2df90a202cdf"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
@@ -136,19 +136,19 @@
     "model",
   ]
   pruneopts = ""
-  revision = "1ba88736f028e37bc17328369e94a537ae9e0234"
-  version = "v0.4.0"
+  revision = "31bed53e4047fd6c510e43a941f90cb31be0972a"
+  version = "v0.6.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:8104ddcc08a1fb39322b65c886bf3a94c216b35268c8d3eed158ca0c6615de27"
+  digest = "1:9b33e539d6bf6e4453668a847392d1e9e6345225ea1426f9341212c652bcbee4"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
     "internal/fs",
   ]
   pruneopts = ""
-  revision = "5867b95ac084bbfee6ea16595c4e05ab009021da"
+  revision = "3f98efb27840a48a7a2898ec80be07674d19f9c8"
+  version = "v0.0.3"
 
 [[projects]]
   digest = "1:381bcbeb112a51493d9d998bbba207a529c73dbb49b3fd789e48c63fac1f192c"
@@ -160,6 +160,14 @@
   pruneopts = ""
   revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
   version = "v1.3.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:8d8dab33e614e3839a47bbb340189458c28c58e60655023d20eeb92b7300768a"
+  name = "golang.org/x/sys"
+  packages = ["windows"]
+  pruneopts = ""
+  revision = "fae7ac547cb717d141c433a2a173315e216b64c4"
 
 [[projects]]
   digest = "1:cedccf16b71e86db87a24f8d4c70b0a855872eb967cb906a66b95de56aefbd0d"

--- a/gauges/backends.go
+++ b/gauges/backends.go
@@ -123,7 +123,7 @@ type backendsByWaitEventType struct {
 }
 
 func (g *Gauges) backendsByWaitEventTypeQuery() string {
-	if postgres.Version(g.version()).Is96Or10() {
+	if postgres.Version(g.version()).IsEqualOrGreaterThan96() {
 		return `
 			SELECT
 			  COUNT(*) AS total,

--- a/gauges/gauge.go
+++ b/gauges/gauge.go
@@ -149,11 +149,11 @@ func (g *Gauges) queryWithTimeout(
 	return err
 }
 
-func (g *Gauges) version() string {
-	var version string
-	if err := g.db.QueryRow("show server_version").Scan(&version); err != nil {
+func (g *Gauges) version() int {
+	var version int
+	if err := g.db.QueryRow("show server_version_num").Scan(&version); err != nil {
 		log.WithField("db", g.name).WithError(err).Error("failed to get postgresql version, assuming 9.6.0")
-		return "9.6.0"
+		return 90600
 	}
 	return version
 }

--- a/gauges/vacuum.go
+++ b/gauges/vacuum.go
@@ -112,7 +112,7 @@ func (g *Gauges) VacuumRunningTotal() prometheus.Gauge {
 		SELECT COUNT(*) FROM pg_stat_progress_vacuum WHERE datname = current_database()
 	`
 
-	if !postgres.Version(g.version()).Is96Or10() {
+	if !postgres.Version(g.version()).IsEqualOrGreaterThan96() {
 		log.WithField("db", g.name).
 			Warn("postgresql_vacuum_running_total disabled because it's only supported for PostgreSQL 9.6 or newer versions")
 		return prometheus.NewGauge(gaugeOpts)

--- a/postgres/version.go
+++ b/postgres/version.go
@@ -3,12 +3,12 @@ package postgres
 // Version for a postgres server
 type Version int
 
-// IsEqualOrGreaterThan96 returns whether this is version is greater than 9.6.x
+// IsEqualOrGreaterThan96 returns whether this is version is greater than 9.6.0
 func (v Version) IsEqualOrGreaterThan96() bool {
 	return v >= 90600
 }
 
-// IsEqualOrGreaterThan10 returns whether this is version is greater than 10.x
+// IsEqualOrGreaterThan10 returns whether this is version is greater than 10.0
 func (v Version) IsEqualOrGreaterThan10() bool {
 	return v >= 100000
 }

--- a/postgres/version.go
+++ b/postgres/version.go
@@ -3,12 +3,12 @@ package postgres
 // Version for a postgres server
 type Version int
 
-// IsEqualOrGreaterThan96 returns whether this is version is greater than 9.6.0
+// IsEqualOrGreaterThan96 returns whether this version is greater than 9.6.0
 func (v Version) IsEqualOrGreaterThan96() bool {
 	return v >= 90600
 }
 
-// IsEqualOrGreaterThan10 returns whether this is version is greater than 10.0
+// IsEqualOrGreaterThan10 returns whether this version is greater than 10.0
 func (v Version) IsEqualOrGreaterThan10() bool {
 	return v >= 100000
 }

--- a/postgres/version.go
+++ b/postgres/version.go
@@ -1,14 +1,22 @@
 package postgres
 
-import "strings"
-
 // Version for a postgres server
-type Version string
+type Version int
+
+// IsEqualOrGreaterThan96 returns whether this is version is greater than 9.6.x
+func (v Version) IsEqualOrGreaterThan96() bool {
+	return v >= 90600
+}
+
+// IsEqualOrGreaterThan10 returns whether this is version is greater than 10.x
+func (v Version) IsEqualOrGreaterThan10() bool {
+	return v >= 100000
+}
 
 // IsWalReplayPausedFunctionName returns the name of the function to verify whether the replication
 // log is paused according to the postgres version
 func (v Version) IsWalReplayPausedFunctionName() string {
-	if v.is10() {
+	if v.IsEqualOrGreaterThan10() {
 		return "pg_is_wal_replay_paused"
 	}
 	return "pg_is_xlog_replay_paused"
@@ -17,7 +25,7 @@ func (v Version) IsWalReplayPausedFunctionName() string {
 // LastWalReceivedLsnFunctionName returns the name of the function that returns the last write-ahead
 // log location received and synced to disk by replication according to the postgres version
 func (v Version) LastWalReceivedLsnFunctionName() string {
-	if v.is10() {
+	if v.IsEqualOrGreaterThan10() {
 		return "pg_last_wal_receive_lsn"
 	}
 	return "pg_last_xlog_receive_location"
@@ -26,7 +34,7 @@ func (v Version) LastWalReceivedLsnFunctionName() string {
 // WalLsnDiffFunctionName returns the name of the function that returns the difference between two write-ahead
 // log locations
 func (v Version) WalLsnDiffFunctionName() string {
-	if v.is10() {
+	if v.IsEqualOrGreaterThan10() {
 		return "pg_wal_lsn_diff"
 	}
 	return "pg_xlog_location_diff"
@@ -35,22 +43,9 @@ func (v Version) WalLsnDiffFunctionName() string {
 // LastWalReplayedLsnFunctionName returns the name of the function that returns the last write-ahead
 // log location replayed during recovery according to the postgres version
 func (v Version) LastWalReplayedLsnFunctionName() string {
-	if v.is10() {
+	if v.IsEqualOrGreaterThan10() {
 		return "pg_last_wal_replay_lsn"
 	}
 	return "pg_last_xlog_replay_location"
 
-}
-
-func (v Version) is96() bool {
-	return strings.HasPrefix(string(v), "9.6.")
-}
-
-func (v Version) is10() bool {
-	return strings.HasPrefix(string(v), "10.")
-}
-
-// Is96Or10 returns whether this is version 9.6.x, 10.x or not
-func (v Version) Is96Or10() bool {
-	return v.is96() || v.is10()
 }

--- a/postgres/version_test.go
+++ b/postgres/version_test.go
@@ -7,30 +7,46 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFunctionVersions(t *testing.T) {
-	is96 := Version.is96
-	is10 := Version.is10
-	is96Or10 := Version.Is96Or10
-
+func TestIsEqualOrGreaterThan96(t *testing.T) {
 	tt := []struct {
-		str      string
-		fn       func(Version) bool
+		version  int
 		expected bool
 	}{
-		{"9.6.6", is96, true},
-		{"9.5.4", is96, false},
-		{"10.3", is10, true},
-		{"9.6.6", is10, false},
-		{"9.6.6", is96Or10, true},
-		{"9.5.4", is96Or10, false},
-		{"10.4", is96Or10, true},
-		{"11.0", is96Or10, false},
+		{90407, false},
+		{90600, true},
+		{90606, true},
+		{100000, true},
+		{100004, true},
+		{110000, true},
+		{110004, true},
 	}
 
 	for _, tc := range tt {
-		testName := fmt.Sprintf("expecting %p(\"%v\") to be %v", tc.fn, tc.str, tc.expected)
+		testName := fmt.Sprintf("expecting IsEqualOrGreaterThan96(\"%v\") to be %v", tc.version, tc.expected)
 		t.Run(testName, func(t *testing.T) {
-			assert.Equal(t, tc.fn(Version(tc.str)), tc.expected)
+			assert.Equal(t, Version(tc.version).IsEqualOrGreaterThan96(), tc.expected)
+		})
+	}
+}
+
+func TestIsEqualOrGreaterThan10(t *testing.T) {
+	tt := []struct {
+		version  int
+		expected bool
+	}{
+		{90407, false},
+		{90600, false},
+		{90606, false},
+		{100000, true},
+		{100004, true},
+		{110000, true},
+		{110004, true},
+	}
+
+	for _, tc := range tt {
+		testName := fmt.Sprintf("expecting IsEqualOrGreaterThan10(\"%v\") to be %v", tc.version, tc.expected)
+		t.Run(testName, func(t *testing.T) {
+			assert.Equal(t, Version(tc.version).IsEqualOrGreaterThan10(), tc.expected)
 		})
 	}
 }


### PR DESCRIPTION
Changed the version related functions to use `server_version_num` instead of `server_version` making it easier to check PostgreSQL version and allowing greater than comparison. 

These changes add support to PostgreSQL 11+

refs https://contaazul.atlassian.net/browse/SRE-576
@ContaAzul/sre 