### PR TITLE
[JARVIS#DE-556] Send replication slots metrics to Prometheus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ go: "1.10"
 addons:
   postgresql: "9.6"
 before_script:
-  - psql -U postgres -c "ALTER SYSTEM SET wal_level TO 'logical';"
+  - psql -U postgres -c "ALTER SYSTEM SET wal_level TO 'logical', max_replication_slots=10;"
   - sudo /etc/init.d/postgresql restart 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ language: go
 go: "1.10"
 addons:
   postgresql: "9.6"
+  command:
+    - "postgres"
+    - "-c"
+    - "wal_level=logical"
 services:
   - docker
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ sudo: required
 language: go
 go: "1.10"
 addons:
-  postgresql: "11.3"
+  postgresql: "11.2"
+  apt:
+    packages:
+      - postgresql-11
 before_script:
-  - psql --version
-  - sudo service postgresql status
   - psql -U travis -c "ALTER SYSTEM SET wal_level TO 'logical';"
   - psql -U travis -c "ALTER SYSTEM SET max_replication_slots TO '10';"
   - sudo /etc/init.d/postgresql restart 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go: "1.10"
 addons:
   postgresql: "11.2"
 before_script:
+  - sudo apt-get install -y postgresql-11 postgresql-client-11
   - psql --version
   - sudo service postgresql status
   - psql -U travis -c "ALTER SYSTEM SET wal_level TO 'logical';"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ go: "1.10"
 addons:
   postgresql: "9.6"
 before_script:
-  - psql -U postgres -c "ALTER SYSTEM SET max_replication_slots TO '10';"
+  - psql -U postgres -c "ALTER SYSTEM SET wal_level TO 'logical';"
+  - sudo /etc/init.d/postgresql restart 
 services:
   - docker
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,8 @@ language: go
 go: "1.10"
 addons:
   postgresql: "9.6"
-  command:
-    - "postgres"
-    - "-c"
-    - "wal_level=logical"
+before_script:
+  - psql -U postgres -c "ALTER SYSTEM SET wal_level TO 'logical';"
 services:
   - docker
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ go: "1.10"
 addons:
   postgresql: "11.2"
 before_script:
-  - psql -U postgres -c "ALTER SYSTEM SET wal_level TO 'logical';"
-  - psql -U postgres -c "ALTER SYSTEM SET max_replication_slots TO '10';"
+  - psql -U travis -c "ALTER SYSTEM SET wal_level TO 'logical';"
+  - psql -U travis -c "ALTER SYSTEM SET max_replication_slots TO '10';"
   - sudo /etc/init.d/postgresql restart 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ go: "1.10"
 addons:
   postgresql: "11.2"
 before_script:
+  - psql --version
+  - sudo service postgresql status
   - psql -U travis -c "ALTER SYSTEM SET wal_level TO 'logical';"
   - psql -U travis -c "ALTER SYSTEM SET max_replication_slots TO '10';"
   - sudo /etc/init.d/postgresql restart 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: go
 go: "1.10"
 addons:
-  postgresql: "11.4"
+  postgresql: "9.6"
 before_script:
   - psql -U postgres -c "ALTER SYSTEM SET wal_level TO 'logical';"
   - psql -U postgres -c "ALTER SYSTEM SET max_replication_slots TO '10';"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ go: "1.10"
 addons:
   postgresql: "9.6"
 before_script:
-  - psql -U postgres -c "ALTER SYSTEM SET wal_level TO 'logical', max_replication_slots=10;"
+  - psql -U postgres -c "ALTER SYSTEM SET wal_level TO 'logical';"
+  - psql -U postgres -c "ALTER SYSTEM SET max_replication_slots TO '10';"
   - sudo /etc/init.d/postgresql restart 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: go
 go: "1.10"
 addons:
-  postgresql: "10"
+  postgresql: "11.2"
 before_script:
   - psql -U postgres -c "ALTER SYSTEM SET wal_level TO 'logical';"
   - psql -U postgres -c "ALTER SYSTEM SET max_replication_slots TO '10';"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ sudo: required
 language: go
 go: "1.10"
 addons:
-  postgresql: "11.2"
+  postgresql: "11.3"
 before_script:
-  - sudo apt-get install -y postgresql-11 postgresql-client-11
   - psql --version
   - sudo service postgresql status
   - psql -U travis -c "ALTER SYSTEM SET wal_level TO 'logical';"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: go
 go: "1.10"
 addons:
-  postgresql: "9.6"
+  postgresql: "10"
 before_script:
   - psql -U postgres -c "ALTER SYSTEM SET wal_level TO 'logical';"
   - psql -U postgres -c "ALTER SYSTEM SET max_replication_slots TO '10';"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ go: "1.10"
 addons:
   postgresql: "9.6"
 before_script:
-  - psql -U postgres -c "ALTER SYSTEM SET wal_level TO 'logical';"
+  - psql -U postgres -c "ALTER SYSTEM SET max_replication_slots TO '10';"
 services:
   - docker
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: go
 go: "1.10"
 addons:
-  postgresql: "9.6"
+  postgresql: "11.4"
 before_script:
   - psql -U postgres -c "ALTER SYSTEM SET wal_level TO 'logical';"
   - psql -U postgres -c "ALTER SYSTEM SET max_replication_slots TO '10';"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ sudo: required
 language: go
 go: "1.10"
 addons:
-  postgresql: "11.2"
-  apt:
-    packages:
-      - postgresql-11
+  postgresql: "9.6"
 before_script:
   - psql -U travis -c "ALTER SYSTEM SET wal_level TO 'logical';"
   - psql -U travis -c "ALTER SYSTEM SET max_replication_slots TO '10';"

--- a/gauges/logical_replication.go
+++ b/gauges/logical_replication.go
@@ -9,7 +9,7 @@ import (
 )
 
 type slots struct {
-	SlotName     string  `db:"slot_name"`
+	Name     string  `db:"slot_name"`
 	Active float64 `db:"active"`
 	TotalLag float64 `db:"total_lag"`
 }

--- a/gauges/logical_replication.go
+++ b/gauges/logical_replication.go
@@ -19,7 +19,7 @@ func (g *Gauges) ReplicationSlotStatus() *prometheus.GaugeVec {
 	var gauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name:        "postgresql_replication_slot_status",
-			Help:        "State of the replication slots",
+			Help:        "Returns 1 if the slot is currently actively being used",
 			ConstLabels: g.labels,
 		},
 		[]string{"slot_name"},

--- a/gauges/logical_replication.go
+++ b/gauges/logical_replication.go
@@ -3,6 +3,8 @@ package gauges
 import (
 	"time"
 
+	"github.com/ContaAzul/postgresql_exporter/postgres"
+	"github.com/apex/log"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -60,6 +62,11 @@ func (g *Gauges) ReplicationSlotLagInMegabytes() *prometheus.GaugeVec {
 		},
 		[]string{"slot_name"},
 	)
+	if !postgres.Version(g.version()).IsEqualOrGreaterThan10() {
+		log.WithField("db", g.name).
+			Warn("postgresql_replication_slot_lag disabled because it's only supported for PostgreSQL 10 or newer versions")
+		return gauge
+	}
 	go func() {
 		for {
 			gauge.Reset()

--- a/gauges/logical_replication.go
+++ b/gauges/logical_replication.go
@@ -10,7 +10,7 @@ import (
 
 type slots struct {
 	Name     string  `db:"slot_name"`
-	Active float64 `db:"active"`
+	Active   float64 `db:"active"`
 	TotalLag float64 `db:"total_lag"`
 }
 
@@ -42,8 +42,8 @@ func (g *Gauges) ReplicationSlotStatus() *prometheus.GaugeVec {
 			); err == nil {
 				for _, slot := range slots {
 					gauge.With(prometheus.Labels{
-						"slot_name": slot.SlotName,
-					}).Set(slot.IsSlotActive)
+						"slot_name": slot.Name,
+					}).Set(slot.Active)
 				}
 			}
 			time.Sleep(g.interval)
@@ -52,12 +52,12 @@ func (g *Gauges) ReplicationSlotStatus() *prometheus.GaugeVec {
 	return gauge
 }
 
-// ReplicationSlotLagInMegabytes returns the total lag from the replication slots
-func (g *Gauges) ReplicationSlotLagInMegabytes() *prometheus.GaugeVec {
+// ReplicationSlotLagInBytes returns the total lag in bytes from the replication slots
+func (g *Gauges) ReplicationSlotLagInBytes() *prometheus.GaugeVec {
 	var gauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name:        "postgresql_replication_slot_lag",
-			Help:        "Total lag of the replication slots",
+			Name:        "postgresql_replication_lag_bytes",
+			Help:        "Total lag in bytes of the replication slots",
 			ConstLabels: g.labels,
 		},
 		[]string{"slot_name"},
@@ -84,8 +84,8 @@ func (g *Gauges) ReplicationSlotLagInMegabytes() *prometheus.GaugeVec {
 			); err == nil {
 				for _, slot := range slots {
 					gauge.With(prometheus.Labels{
-						"slot_name": slot.SlotName,
-					}).Set(slot.SlotTotalLag)
+						"slot_name": slot.Name,
+					}).Set(slot.TotalLag)
 				}
 			}
 			time.Sleep(g.interval)

--- a/gauges/logical_replication.go
+++ b/gauges/logical_replication.go
@@ -10,7 +10,7 @@ import (
 
 type slots struct {
 	SlotName     string  `db:"slot_name"`
-	IsSlotActive float64 `db:"active"`
+	Active float64 `db:"active"`
 	SlotTotalLag float64 `db:"total_lag"`
 }
 

--- a/gauges/logical_replication.go
+++ b/gauges/logical_replication.go
@@ -1,0 +1,92 @@
+package gauges
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type slots struct {
+	DatabaseName string  `db:"database_name"`
+	SlotName     string  `db:"slot_name"`
+	Active       float64 `db:"active"`
+	TotalLag     float64 `db:"total_lag"`
+}
+
+// ReplicationSlotStatus returns the state of the replication slots
+func (g *Gauges) ReplicationSlotStatus() *prometheus.GaugeVec {
+	var gauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:        "postgresql_replication_slot_status",
+			Help:        "State of the replication slots",
+			ConstLabels: g.labels,
+		},
+		[]string{"database_name", "slot_name"},
+	)
+	go func() {
+		for {
+			gauge.Reset()
+			var slots []slots
+			if err := g.query(
+				`
+					SELECT
+						"database" AS database_name,
+						slot_name,
+						active::int
+					FROM pg_replication_slots
+					WHERE slot_type = 'logical';
+				`,
+				&slots,
+				emptyParams,
+			); err == nil {
+				for _, slot := range slots {
+					gauge.With(prometheus.Labels{
+						"database_name": lock.DatabaseName,
+						"slot_name":     lock.SlotName,
+					}).Set(slot.Active)
+				}
+			}
+			time.Sleep(g.interval)
+		}
+	}()
+	return gauge
+}
+
+// ReplicationSlotLagInMegabytes returns the total lag from the replication slots
+func (g *Gauges) ReplicationSlotLagInMegabytes() *prometheus.GaugeVec {
+	var gauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:        "postgresql_replication_slot_lag",
+			Help:        "Total lag of the replication slots",
+			ConstLabels: g.labels,
+		},
+		[]string{"database_name", "slot_name"},
+	)
+	go func() {
+		for {
+			gauge.Reset()
+			var slots []slots
+			if err := g.query(
+				`
+					SELECT
+						"database" AS database_name,
+						slot_name,
+						round(pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn) / 1048576, 0) AS total_lag
+					FROM pg_replication_slots
+					WHERE slot_type = 'logical';
+				`,
+				&slots,
+				emptyParams,
+			); err == nil {
+				for _, slot := range slots {
+					gauge.With(prometheus.Labels{
+						"database_name": lock.DatabaseName,
+						"slot_name":     lock.SlotName,
+					}).Set(slot.TotalLag)
+				}
+			}
+			time.Sleep(g.interval)
+		}
+	}()
+	return gauge
+}

--- a/gauges/logical_replication.go
+++ b/gauges/logical_replication.go
@@ -57,7 +57,7 @@ func (g *Gauges) ReplicationSlotLagInBytes() *prometheus.GaugeVec {
 	var gauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name:        "postgresql_replication_lag_bytes",
-			Help:        "Total lag in bytes of the replication slots",
+			Help:        "Total lag of the replication slots in bytes",
 			ConstLabels: g.labels,
 		},
 		[]string{"slot_name"},

--- a/gauges/logical_replication.go
+++ b/gauges/logical_replication.go
@@ -11,7 +11,7 @@ import (
 type slots struct {
 	SlotName     string  `db:"slot_name"`
 	Active float64 `db:"active"`
-	SlotTotalLag float64 `db:"total_lag"`
+	TotalLag float64 `db:"total_lag"`
 }
 
 // ReplicationSlotStatus returns the state of the replication slots

--- a/gauges/logical_replication.go
+++ b/gauges/logical_replication.go
@@ -71,7 +71,7 @@ func (g *Gauges) ReplicationSlotLagInBytes() *prometheus.GaugeVec {
 					`
 						SELECT
 							slot_name,
-							round(%s(%s(), confirmed_flush_lsn) / 1048576, 0) AS total_lag
+							%s(%s(), confirmed_flush_lsn) AS total_lag
 						FROM pg_replication_slots
 						WHERE slot_type = 'logical'
 						AND "database" = current_database();

--- a/gauges/logical_replication_test.go
+++ b/gauges/logical_replication_test.go
@@ -2,6 +2,7 @@ package gauges
 
 import (
 	"database/sql"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,7 +13,7 @@ func TestReplicationSlotStatus(t *testing.T) {
 	var assert = assert.New(t)
 	db, gauges, close := prepare(t)
 	defer close()
-	dropTestLogicalReplicationSlot := createTestLogicalReplicationSlot(t, db)
+	dropTestLogicalReplicationSlot := createTestLogicalReplicationSlot("test_status", t, db)
 	defer dropTestLogicalReplicationSlot()
 	var metrics = evaluate(t, gauges.ReplicationSlotStatus())
 	assert.Len(metrics, 1)
@@ -24,19 +25,19 @@ func TestReplicationSlotLagInMegabytes(t *testing.T) {
 	var assert = assert.New(t)
 	db, gauges, close := prepare(t)
 	defer close()
-	dropTestLogicalReplicationSlot := createTestLogicalReplicationSlot(t, db)
+	dropTestLogicalReplicationSlot := createTestLogicalReplicationSlot("test_lag", t, db)
 	defer dropTestLogicalReplicationSlot()
 	var metrics = evaluate(t, gauges.ReplicationSlotLagInMegabytes())
 	assert.Len(metrics, 1)
-	assertGreaterThan(t, -1, metrics[0])
+	assertEqual(t, 0, metrics[0])
 	assertNoErrs(t, gauges)
 }
 
-func createTestLogicalReplicationSlot(t *testing.T, db *sql.DB) func() {
-	_, err := db.Exec("SELECT * FROM pg_create_logical_replication_slot('integration_test', 'test_decoding');")
+func createTestLogicalReplicationSlot(slotName string, t *testing.T, db *sql.DB) func() {
+	_, err := db.Exec(fmt.Sprintf("SELECT * FROM pg_create_logical_replication_slot('%s', 'test_decoding');", slotName))
 	require.NoError(t, err)
 	return func() {
-		_, err := db.Exec("SELECT pg_drop_replication_slot('integration_test');")
+		_, err := db.Exec(fmt.Sprintf("SELECT pg_drop_replication_slot('%s');", slotName))
 		assert.New(t).NoError(err)
 	}
 }

--- a/gauges/logical_replication_test.go
+++ b/gauges/logical_replication_test.go
@@ -1,27 +1,42 @@
 package gauges
 
 import (
+	"database/sql"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReplicationSlotStatus(t *testing.T) {
 	var assert = assert.New(t)
-	_, gauges, close := prepare(t)
+	db, gauges, close := prepare(t)
 	defer close()
+	dropTestLogicalReplicationSlot := createTestLogicalReplicationSlot(t, db)
+	defer dropTestLogicalReplicationSlot()
 	var metrics = evaluate(t, gauges.ReplicationSlotStatus())
 	assert.Len(metrics, 1)
-	assertGreaterThan(t, -1, metrics[0])
+	assertEqual(t, 0, metrics[0])
 	assertNoErrs(t, gauges)
 }
 
 func TestReplicationSlotLagInMegabytes(t *testing.T) {
 	var assert = assert.New(t)
-	_, gauges, close := prepare(t)
+	db, gauges, close := prepare(t)
 	defer close()
+	dropTestLogicalReplicationSlot := createTestLogicalReplicationSlot(t, db)
+	defer dropTestLogicalReplicationSlot()
 	var metrics = evaluate(t, gauges.ReplicationSlotLagInMegabytes())
 	assert.Len(metrics, 1)
 	assertGreaterThan(t, -1, metrics[0])
 	assertNoErrs(t, gauges)
+}
+
+func createTestLogicalReplicationSlot(t *testing.T, db *sql.DB) func() {
+	_, err := db.Exec("SELECT * FROM pg_create_logical_replication_slot('integration_test', 'test_decoding');")
+	require.NoError(t, err)
+	return func() {
+		_, err := db.Exec("SELECT pg_drop_replication_slot('integration_test');")
+		assert.New(t).NoError(err)
+	}
 }

--- a/gauges/logical_replication_test.go
+++ b/gauges/logical_replication_test.go
@@ -1,0 +1,27 @@
+package gauges
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReplicationSlotStatus(t *testing.T) {
+	var assert = assert.New(t)
+	_, gauges, close := prepare(t)
+	defer close()
+	var metrics = evaluate(t, gauges.ReplicationSlotStatus())
+	assert.Len(metrics, 1)
+	assertGreaterThan(t, -1, metrics[0])
+	assertNoErrs(t, gauges)
+}
+
+func TestReplicationSlotLagInMegabytes(t *testing.T) {
+	var assert = assert.New(t)
+	_, gauges, close := prepare(t)
+	defer close()
+	var metrics = evaluate(t, gauges.ReplicationSlotLagInMegabytes())
+	assert.Len(metrics, 1)
+	assertGreaterThan(t, -1, metrics[0])
+	assertNoErrs(t, gauges)
+}

--- a/gauges/logical_replication_test.go
+++ b/gauges/logical_replication_test.go
@@ -27,7 +27,7 @@ func TestReplicationSlotLagInMegabytes(t *testing.T) {
 	defer close()
 	dropTestLogicalReplicationSlot := createTestLogicalReplicationSlot("test_lag", t, db)
 	defer dropTestLogicalReplicationSlot()
-	var metrics = evaluate(t, gauges.ReplicationSlotLagInMegabytes())
+	var metrics = evaluate(t, gauges.ReplicationDelayInBytes())
 	assert.Len(metrics, 1)
 	assertEqual(t, 0, metrics[0])
 	assertNoErrs(t, gauges)

--- a/gauges/logical_replication_test.go
+++ b/gauges/logical_replication_test.go
@@ -28,8 +28,7 @@ func TestReplicationSlotLagInMegabytes(t *testing.T) {
 	dropTestLogicalReplicationSlot := createTestLogicalReplicationSlot("test_lag", t, db)
 	defer dropTestLogicalReplicationSlot()
 	var metrics = evaluate(t, gauges.ReplicationSlotLagInMegabytes())
-	assert.Len(metrics, 1)
-	assertEqual(t, 0, metrics[0])
+	assert.Len(metrics, 0)
 	assertNoErrs(t, gauges)
 }
 

--- a/gauges/logical_replication_test.go
+++ b/gauges/logical_replication_test.go
@@ -28,7 +28,8 @@ func TestReplicationSlotLagInMegabytes(t *testing.T) {
 	dropTestLogicalReplicationSlot := createTestLogicalReplicationSlot("test_lag", t, db)
 	defer dropTestLogicalReplicationSlot()
 	var metrics = evaluate(t, gauges.ReplicationSlotLagInMegabytes())
-	assert.Len(metrics, 0)
+	assert.Len(metrics, 1)
+	assertEqual(t, 0, metrics[0])
 	assertNoErrs(t, gauges)
 }
 

--- a/main.go
+++ b/main.go
@@ -121,5 +121,5 @@ func watch(db *sql.DB, reg prometheus.Registerer, name string) {
 	reg.MustRegister(gauges.LastTimeAutoVacuumRan())
 	reg.MustRegister(gauges.VacuumRunningTotal())
 	reg.MustRegister(gauges.ReplicationSlotStatus())
-	reg.MustRegister(gauges.ReplicationSlotLagInMegabytes())
+	reg.MustRegister(gauges.ReplicationSlotLagInBytes())
 }

--- a/main.go
+++ b/main.go
@@ -120,4 +120,6 @@ func watch(db *sql.DB, reg prometheus.Registerer, name string) {
 	reg.MustRegister(gauges.LastTimeVacuumRan())
 	reg.MustRegister(gauges.LastTimeAutoVacuumRan())
 	reg.MustRegister(gauges.VacuumRunningTotal())
+	reg.MustRegister(gauges.ReplicationSlotStatus())
+	reg.MustRegister(gauges.ReplicationSlotLagInMegabytes())
 }

--- a/postgres/version.go
+++ b/postgres/version.go
@@ -47,5 +47,12 @@ func (v Version) LastWalReplayedLsnFunctionName() string {
 		return "pg_last_wal_replay_lsn"
 	}
 	return "pg_last_xlog_replay_location"
+}
 
+// CurrentWalLsnFunctionName returns the name of the function that gets the current wal LSN
+func (v Version) CurrentWalLsnFunctionName() string {
+	if v.IsEqualOrGreaterThan10() {
+		return "pg_current_wal_lsn"
+	}
+	return "pg_current_xlog_location"
 }

--- a/postgres/version.go
+++ b/postgres/version.go
@@ -49,7 +49,8 @@ func (v Version) LastWalReplayedLsnFunctionName() string {
 	return "pg_last_xlog_replay_location"
 }
 
-// CurrentWalLsnFunctionName returns the name of the function that gets the current wal LSN
+// CurrentWalLsnFunctionName returns the name of the function that gets current 
+// write-ahead log write location according to the postgres version
 func (v Version) CurrentWalLsnFunctionName() string {
 	if v.IsEqualOrGreaterThan10() {
 		return "pg_current_wal_lsn"


### PR DESCRIPTION
Send the `status` and `lag` metrics to Prometheus.
We will add two alerts, one when the status is equal to zero for more than five minutes, and another when the lag (in MB) is greater than X mb (TBD);

The local results are:

```
# HELP postgresql_replication_slot_lag Total lag of the replication slots
# TYPE postgresql_replication_slot_lag gauge
postgresql_replication_slot_lag{database_name="uuid",slot_name="my_dummy_wal"} 499
# HELP postgresql_replication_slot_status State of the replication slots
# TYPE postgresql_replication_slot_status gauge
postgresql_replication_slot_status{database_name="uuid",slot_name="my_dummy_wal"} 0
```


### Links
https://contaazul.atlassian.net/browse/DE-556