### PR TITLE
[SRE-1209] - Adding Current Backends

### DIFF
--- a/gauges/backends.go
+++ b/gauges/backends.go
@@ -31,6 +31,18 @@ func (g *Gauges) MaxBackends() prometheus.Gauge {
 	)
 }
 
+// CurrentBackends returns the number of backends currently connected to all databases 
+func (g *Gauges) CurrentBackends() prometheus.Gauge {
+	return g.new(
+		prometheus.GaugeOpts{
+			Name:        "postgresql_current_backends",
+			Help:        "Current number of concurrent connections in all databases",
+			ConstLabels: g.labels,
+		},
+		"SELECT sum(numbackends) FROM pg_stat_database;",
+	)
+}
+
 type backendsByState struct {
 	Total float64 `db:"total"`
 	State string  `db:"state"`

--- a/gauges/backends.go
+++ b/gauges/backends.go
@@ -31,8 +31,8 @@ func (g *Gauges) MaxBackends() prometheus.Gauge {
 	)
 }
 
-// CurrentBackends returns the number of backends currently connected to all databases 
-func (g *Gauges) CurrentBackends() prometheus.Gauge {
+// InstanceConnectedBackends returns the number of backends currently connected to all databases 
+func (g *Gauges) InstanceConnectedBackends() prometheus.Gauge {
 	return g.new(
 		prometheus.GaugeOpts{
 			Name:        "postgresql_instance_connected_backends",

--- a/gauges/backends.go
+++ b/gauges/backends.go
@@ -35,7 +35,7 @@ func (g *Gauges) MaxBackends() prometheus.Gauge {
 func (g *Gauges) CurrentBackends() prometheus.Gauge {
 	return g.new(
 		prometheus.GaugeOpts{
-			Name:        "postgresql_current_backends",
+			Name:        "postgresql_instance_connected_backends",
 			Help:        "Current number of concurrent connections in all databases",
 			ConstLabels: g.labels,
 		},

--- a/gauges/backends_test.go
+++ b/gauges/backends_test.go
@@ -30,7 +30,7 @@ func TestInstanceConnectedBackends(t *testing.T) {
 	var assert = assert.New(t)
 	_, gauges, close := prepare(t)
 	defer close()
-	var metrics = evaluate(t, gauges.MaxBackends())
+	var metrics = evaluate(t, gauges.InstanceConnectedBackends())
 	assert.Len(metrics, 1)
 	assertGreaterThan(t, 0, metrics[0])
 	assertNoErrs(t, gauges)

--- a/gauges/backends_test.go
+++ b/gauges/backends_test.go
@@ -26,6 +26,16 @@ func TestMaxBackends(t *testing.T) {
 	assertNoErrs(t, gauges)
 }
 
+func TestCurrentBackends(t *testing.T) {
+	var assert = assert.New(t)
+	_, gauges, close := prepare(t)
+	defer close()
+	var metrics = evaluate(t, gauges.MaxBackends())
+	assert.Len(metrics, 1)
+	assertGreaterThan(t, 0, metrics[0])
+	assertNoErrs(t, gauges)
+}
+
 func TestBackendsByState(t *testing.T) {
 	var assert = assert.New(t)
 	_, gauges, close := prepare(t)

--- a/gauges/backends_test.go
+++ b/gauges/backends_test.go
@@ -26,7 +26,7 @@ func TestMaxBackends(t *testing.T) {
 	assertNoErrs(t, gauges)
 }
 
-func TestCurrentBackends(t *testing.T) {
+func TestInstanceConnectedBackends(t *testing.T) {
 	var assert = assert.New(t)
 	_, gauges, close := prepare(t)
 	defer close()

--- a/main.go
+++ b/main.go
@@ -82,6 +82,7 @@ func watch(db *sql.DB, reg prometheus.Registerer, name string) {
 
 	reg.MustRegister(gauges.ConnectedBackends())
 	reg.MustRegister(gauges.MaxBackends())
+	reg.MustRegister(gauges.CurrentBackends())
 	reg.MustRegister(gauges.BackendsByState())
 	reg.MustRegister(gauges.BackendsByUserAndClientAddress())
 	reg.MustRegister(gauges.BackendsByWaitEventType())

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func watch(db *sql.DB, reg prometheus.Registerer, name string) {
 
 	reg.MustRegister(gauges.ConnectedBackends())
 	reg.MustRegister(gauges.MaxBackends())
-	reg.MustRegister(gauges.CurrentBackends())
+	reg.MustRegister(gauges.InstanceConnectedBackends())
 	reg.MustRegister(gauges.BackendsByState())
 	reg.MustRegister(gauges.BackendsByUserAndClientAddress())
 	reg.MustRegister(gauges.BackendsByWaitEventType())


### PR DESCRIPTION
It adds a metric (`postgresql_instance_connected_backends`) that sums all connections established with the database instance, similar to the `MaxConnections` metric. 

That allows calculating the remaining available connections. 

**Update:**
_As mentioned here https://github.com/ContaAzul/postgresql_exporter/pull/63#discussion_r351423610 it has a down-side. We continue to export the same metric value per database. So, a multiple databases instance will have the same value in multiples metrics.  In a future release, we're planning to rewrite the config file structure to allow grouping databases per instance._