### PR TITLE
Fix bloat metrics

### DIFF
--- a/gauges/indexes.go
+++ b/gauges/indexes.go
@@ -265,6 +265,7 @@ func (g *Gauges) IndexBloat() *prometheus.GaugeVec {
 	)
 	go func() {
 		for {
+			gauge.Reset()
 			var indexes []indexBloat
 			if err := g.query(indexBloatQuery, &indexes, emptyParams); err == nil {
 				for _, idx := range indexes {

--- a/gauges/tables.go
+++ b/gauges/tables.go
@@ -143,6 +143,7 @@ func (g *Gauges) TableBloat() *prometheus.GaugeVec {
 	)
 	go func() {
 		for {
+			gauge.Reset()
 			var tables []tableBloat
 			if err := g.query(tableBloatQuery, &tables, emptyParams); err == nil {
 				for _, table := range tables {


### PR DESCRIPTION
When bloat is cleaned, the query no longer returns the table that had bloat, so the metric returns forever the old value