### PR TITLE
feat: add support to gcp sqlproxy

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -3,3 +3,11 @@ databases:
   url: postgres://localhost:5432/dba?sslmode=disable
 - name: dbb
   url: postgres://user:pwd@mydb.foo.bar:5432/dbb
+- name: dbc
+  # Used to connect into gcp sql instance using sqlproxy, when defined the URL is not necessary.
+  # https://cloud.google.com/sql/docs/postgres/connect-admin-proxy#go
+  sql:
+    conection_name: gcp-project:region:instance-name
+    database_name: dbc
+    database_user: user
+    database_password: pwd

--- a/config.yml
+++ b/config.yml
@@ -7,7 +7,7 @@ databases:
   # Used to connect into gcp sql instance using sqlproxy, when defined the URL is not necessary.
   # https://cloud.google.com/sql/docs/postgres/connect-admin-proxy#go
   sql:
-    conection_name: gcp-project:region:instance-name
+    connection_name: gcp-project:region:instance-name
     database_name: dbc
     database_user: user
     database_password: pwd

--- a/config/config.go
+++ b/config/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Sql struct {
-	ConnectionName   string `yaml:"conection_name,omitempty"`
+	ConnectionName   string `yaml:"connection_name,omitempty"`
 	DatabaseName     string `yaml:"database_name,omitempty"`
 	DatabaseUser     string `yaml:"database_user,omitempty"`
 	DatabasePassword string `yaml:"database_password,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -8,9 +8,17 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+type Sql struct {
+	ConnectionName   string `yaml:"conection_name,omitempty"`
+	DatabaseName     string `yaml:"database_name,omitempty"`
+	DatabaseUser     string `yaml:"database_user,omitempty"`
+	DatabasePassword string `yaml:"database_password,omitempty"`
+}
+
 type Database struct {
 	URL  string `yaml:"url,omitempty"`
 	Name string `yaml:"name,omitempty"`
+	Sql  Sql    `yaml:"sql,omitempty"`
 }
 
 type Config struct {
@@ -38,8 +46,8 @@ func validate(config Config) error {
 		if conf.Name == "" {
 			return errors.New("failed to validate configuration. Database name cannot be empty")
 		}
-		if conf.URL == "" {
-			return fmt.Errorf("failed to validate configuration. URL for database '%s' cannot be empty", conf.Name)
+		if conf.URL == "" && conf.Sql.ConnectionName == "" {
+			return fmt.Errorf("failed to validate configuration. URL or sql field cannot be empty in the '%s' database", conf.Name)
 		}
 		if names[conf.Name] {
 			return fmt.Errorf("failed to validate configuration. A database named '%s' has already been declared", conf.Name)

--- a/config/testdata/valid-config.yml
+++ b/config/testdata/valid-config.yml
@@ -3,3 +3,9 @@ databases:
   url: postgres://localhost:5432/dba?sslmode=disable
 - name: dbb
   url: postgres://user:pwd@mydb.foo.bar:5432/dbb
+- name: dbc
+  sql:
+    conection_name: gcp-project:region:instance-name
+    database_name: dbc
+    database_user: user
+    database_password: pwd

--- a/config/testdata/valid-config.yml
+++ b/config/testdata/valid-config.yml
@@ -5,7 +5,7 @@ databases:
   url: postgres://user:pwd@mydb.foo.bar:5432/dbb
 - name: dbc
   sql:
-    conection_name: gcp-project:region:instance-name
+    connection_name: gcp-project:region:instance-name
     database_name: dbc
     database_user: user
     database_password: pwd


### PR DESCRIPTION
I'd like to include gcp sqlproxy support to this postgresl-exporter

This way will be easier to monitoring SQL instances without any other companion proxy or exposing instance endpoints. 
