### PR TITLE
feat: add docker multi stage and ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
+FROM golang:alpine as build
+RUN apk --no-cache add ca-certificates make
+WORKDIR /go/src/app
+COPY . .
+RUN make build
+
 FROM scratch
 EXPOSE 9111
 WORKDIR /
-COPY postgresql_exporter .
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build /go/src/app/postgresql_exporter /
 ENTRYPOINT ["./postgresql_exporter"]


### PR DESCRIPTION
To connect to google sql using [proxy](https://github.com/ContaAzul/postgresql_exporter/pull/68) We need to include ca-certificates