### PR TITLE
Ajuste de monitoramento de fragmentação de indices e tabelas

### DIFF
--- a/gauges/indexes.go
+++ b/gauges/indexes.go
@@ -238,7 +238,7 @@ SELECT dbname as database_name, nspname as schema_name, table_name, index_name,
 	index_scans
 FROM raw_bloat
 )
-SELECT table_name, index_name, COALESCE(bloat_pct,0)
+SELECT table_name, index_name, COALESCE(bloat_pct,0) as bloat_pct
 FROM format_bloat
 WHERE database_name = current_database()
 --AND bloat_pct > 50

--- a/gauges/indexes.go
+++ b/gauges/indexes.go
@@ -238,11 +238,11 @@ SELECT dbname as database_name, nspname as schema_name, table_name, index_name,
 	index_scans
 FROM raw_bloat
 )
-SELECT table_name, index_name, bloat_pct
+SELECT table_name, index_name, COALESCE(bloat_pct,0)
 FROM format_bloat
 WHERE database_name = current_database()
-AND bloat_pct > 50
-AND bloat_mb > 10
+--AND bloat_pct > 50
+--AND bloat_mb > 10
 ORDER BY bloat_mb DESC
 `
 

--- a/gauges/tables.go
+++ b/gauges/tables.go
@@ -118,10 +118,10 @@ WITH constants AS (
 	FROM table_estimates_plus
 	)
 	SELECT tablename,
-		pct_bloat
+		COALESCE(pct_bloat,0)
 	FROM bloat_data
-	WHERE ( pct_bloat >= 30 AND mb_bloat >= 10 )
-	OR ( pct_bloat >= 20 AND mb_bloat >= 1000 )
+--	WHERE ( pct_bloat >= 30 AND mb_bloat >= 10 )
+--	OR ( pct_bloat >= 20 AND mb_bloat >= 1000 )
 	ORDER BY pct_bloat DESC
 `
 
@@ -221,8 +221,8 @@ func (g *Gauges) TableUsage() *prometheus.GaugeVec {
 }
 
 var tableSecScansQuery = `
-	select relname, 
-		coalesce(seq_scan, 0) as seq_scan, 
+	select relname,
+		coalesce(seq_scan, 0) as seq_scan,
 		coalesce(idx_scan, 0) as idx_scan
 	from pg_stat_user_tables
 `

--- a/gauges/tables.go
+++ b/gauges/tables.go
@@ -118,7 +118,7 @@ WITH constants AS (
 	FROM table_estimates_plus
 	)
 	SELECT tablename,
-		COALESCE(pct_bloat,0)
+		COALESCE(pct_bloat,0) as pct_bloat
 	FROM bloat_data
 --	WHERE ( pct_bloat >= 30 AND mb_bloat >= 10 )
 --	OR ( pct_bloat >= 20 AND mb_bloat >= 1000 )


### PR DESCRIPTION
Ajuste de duas queries para refletir melhor as manutenções diárias.

Foi removido um filtro da querie, permitindo o retorno da estimativa de bloat para todas as tabelas e indices. Com isso, o número de falsos positivos no canal #incidents deve dimiuir. 

Outra melhoria que esse PR trás é a possibilidade de usar o thanos para alimentar os scripts de manutenção de banco. 